### PR TITLE
fix container data section initialization

### DIFF
--- a/library/secureshield/core/src/v2/secureshield_vmpu_arc.c
+++ b/library/secureshield/core/src/v2/secureshield_vmpu_arc.c
@@ -588,7 +588,7 @@ void vmpu_ac_container(uint8_t container_id, const CONTAINER_CONFIG *container_c
 		vmpu_ac_mem(container_id, container_cfg->data_start, size, SECURESHIELD_ACDEF_URAM | secure);
 
 		if (container_id) {
-			memcpy(container_cfg->data_start, container_cfg->data_load_start, VMPU_REGION_SIZE(container_cfg->data_end, container_cfg->data_start));
+			memcpy(container_cfg->data_start, container_cfg->data_load_start, VMPU_REGION_SIZE(container_cfg->data_start, container_cfg->data_end));
 			memset(container_cfg->bss_start, 0, VMPU_REGION_SIZE(container_cfg->bss_end, container_cfg->bss_start));
 		}
 	}


### PR DESCRIPTION
size argument to memcpy() was calculated incorrect (always 0), so to be initialized data didn't get initialized.