### PR TITLE
mbedtls update to mbedtls-2.4.1

### DIFF
--- a/middleware/mbedtls/0001-Add-embARC-FreeRTOS-LwIP-support-to-mbedtls.patch
+++ b/middleware/mbedtls/0001-Add-embARC-FreeRTOS-LwIP-support-to-mbedtls.patch
@@ -1,539 +1,192 @@
-From 602e2d3bb9f8b32643f5ec7ae4f1342580a4a393 Mon Sep 17 00:00:00 2001
-From: Huaqi Fang <Huaqi.Fang@synopsys.com>
-Date: Tue, 3 May 2016 14:27:18 +0800
-Subject: [PATCH] Add embARC(FreeRTOS+LwIP) support to mbedtls
+From 77dd67234edd55942f9ddb4eef2deba0b4b84569 Mon Sep 17 00:00:00 2001
+From: XiangcaiHuang <xiangcai@synopsys.com>
+Date: Thu, 17 Aug 2017 11:21:12 +0800
+Subject: [PATCH] Add embARC (FreeRTOS+LwIP) support to mbedtls
 
 ---
- embARC/net_alt.c       | 509 +++++++++++++++++++++++++++++++++++++++++++
- embARC/threading_alt.c |  80 +++++++
- embARC/threading_alt.h |  65 ++++++
- embARC/timing_alt.c    | 111 ++++++++++
- embARC/timing_alt.h    | 136 ++++++++++++
- library/net.c          | 580 -------------------------------------------------
- library/threading.c    |  11 +
- 7 files changed, 912 insertions(+), 580 deletions(-)
- create mode 100644 embARC/net_alt.c
+ library/net_sockets.c => embARC/net_alt.c |  94 ++-------------------
+ embARC/threading_alt.c                    |  80 ++++++++++++++++++
+ embARC/threading_alt.h                    |  65 ++++++++++++++
+ embARC/timing_alt.c                       | 111 ++++++++++++++++++++++++
+ embARC/timing_alt.h                       | 136 ++++++++++++++++++++++++++++++
+ library/ssl_srv.c                         |   2 +
+ library/ssl_tls.c                         |  21 ++++-
+ library/threading.c                       |  11 +++
+ 8 files changed, 434 insertions(+), 86 deletions(-)
+ rename library/net_sockets.c => embARC/net_alt.c (85%)
  create mode 100644 embARC/threading_alt.c
  create mode 100644 embARC/threading_alt.h
  create mode 100644 embARC/timing_alt.c
  create mode 100644 embARC/timing_alt.h
- delete mode 100644 library/net.c
 
-diff --git a/embARC/net_alt.c b/embARC/net_alt.c
-new file mode 100644
-index 0000000..5c0bf0c
---- /dev/null
+diff --git a/library/net_sockets.c b/embARC/net_alt.c
+similarity index 85%
+rename from library/net_sockets.c
+rename to embARC/net_alt.c
+index cc06cbf..5c0bf0c 100644
+--- a/library/net_sockets.c
 +++ b/embARC/net_alt.c
-@@ -0,0 +1,509 @@
-+/*
-+ *  TCP/IP or UDP/IP networking functions
-+ *
-+ *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
-+ *  SPDX-License-Identifier: Apache-2.0
-+ *
-+ *  Licensed under the Apache License, Version 2.0 (the "License"); you may
-+ *  not use this file except in compliance with the License.
-+ *  You may obtain a copy of the License at
-+ *
-+ *  http://www.apache.org/licenses/LICENSE-2.0
-+ *
-+ *  Unless required by applicable law or agreed to in writing, software
-+ *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-+ *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-+ *  See the License for the specific language governing permissions and
-+ *  limitations under the License.
-+ *
-+ *  This file is part of mbed TLS (https://tls.mbed.org)
-+ */
-+
-+#if !defined(MBEDTLS_CONFIG_FILE)
-+#include "mbedtls/config.h"
-+#else
-+#include MBEDTLS_CONFIG_FILE
-+#endif
-+
-+#if defined(MBEDTLS_NET_C)
-+
+@@ -27,98 +27,26 @@
+ 
+ #if defined(MBEDTLS_NET_C)
+ 
+-#if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
+-    !defined(__APPLE__) && !defined(_WIN32)
+-#error "This module only works on Unix and Windows, see MBEDTLS_NET_C in config.h"
+-#endif
+-
+-#if defined(MBEDTLS_PLATFORM_C)
+-#include "mbedtls/platform.h"
+-#else
+-#include <stdlib.h>
+-#endif
+-
+-#include "mbedtls/net_sockets.h"
 +#include "mbedtls/net.h"
-+
-+#include <string.h>
-+#include <sys/types.h>
-+#include <sys/socket.h>
-+#include <netdb.h>
-+#include <errno.h>
-+
+ 
+ #include <string.h>
+-
+-#if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(EFIX64) && \
+-    !defined(EFI32)
+-
+-#ifdef _WIN32_WINNT
+-#undef _WIN32_WINNT
+-#endif
+-/* Enables getaddrinfo() & Co */
+-#define _WIN32_WINNT 0x0501
+-#include <ws2tcpip.h>
+-
+-#include <winsock2.h>
+-#include <windows.h>
+-
+-#if defined(_MSC_VER)
+-#if defined(_WIN32_WCE)
+-#pragma comment( lib, "ws2.lib" )
+-#else
+-#pragma comment( lib, "ws2_32.lib" )
+-#endif
+-#endif /* _MSC_VER */
+-
+-#define read(fd,buf,len)        recv(fd,(char*)buf,(int) len,0)
+-#define write(fd,buf,len)       send(fd,(char*)buf,(int) len,0)
+-#define close(fd)               closesocket(fd)
+-
+-static int wsa_init_done = 0;
+-
+-#else /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
+-
+ #include <sys/types.h>
+ #include <sys/socket.h>
+-#include <netinet/in.h>
+-#include <arpa/inet.h>
+-#include <sys/time.h>
+-#include <unistd.h>
+-#include <signal.h>
+-#include <fcntl.h>
+ #include <netdb.h>
+ #include <errno.h>
+ 
+-#endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
+-
+-/* Some MS functions want int and MSVC warns if we pass size_t,
+- * but the standard fucntions use socklen_t, so cast only for MSVC */
+-#if defined(_MSC_VER)
+-#define MSVC_INT_CAST   (int)
+-#else
+-#define MSVC_INT_CAST
+-#endif
+-
 +#include <stdlib.h>
-+#include <stdio.h>
-+#include <time.h>
-+#include <stdint.h>
-+
+ #include <stdio.h>
+-
+ #include <time.h>
+-
+ #include <stdint.h>
+ 
 +#define MSVC_INT_CAST
 +
-+/*
-+ * Prepare for using the sockets interface
-+ */
-+static int net_prepare( void )
-+{
-+    return( 0 );
-+}
-+
-+/*
-+ * Initialize a context
-+ */
-+void mbedtls_net_init( mbedtls_net_context *ctx )
-+{
-+    ctx->fd = -1;
-+}
-+
-+/*
-+ * Initiate a TCP connection with host:port and the given protocol
-+ */
-+int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char *port, int proto )
-+{
-+    int ret;
-+    struct addrinfo hints, *addr_list, *cur;
-+
-+    if( ( ret = net_prepare() ) != 0 )
-+        return( ret );
-+
-+    /* Do name resolution with both IPv6 and IPv4 */
-+    memset( &hints, 0, sizeof( hints ) );
-+    hints.ai_family = AF_UNSPEC;
-+    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
-+    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
-+
-+    if( getaddrinfo( host, port, &hints, &addr_list ) != 0 )
-+        return( MBEDTLS_ERR_NET_UNKNOWN_HOST );
-+
-+    /* Try the sockaddrs until a connection succeeds */
-+    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
-+    for( cur = addr_list; cur != NULL; cur = cur->ai_next )
-+    {
-+        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
-+                            cur->ai_protocol );
-+        if( ctx->fd < 0 )
-+        {
-+            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
-+            continue;
-+        }
-+
-+        if( connect( ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) == 0 )
-+        {
-+            ret = 0;
-+            break;
-+        }
-+
-+        close( ctx->fd );
-+        ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
-+    }
-+
-+    freeaddrinfo( addr_list );
-+
-+    return( ret );
-+}
-+
-+/*
-+ * Create a listening socket on bind_ip:port
-+ */
-+int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto )
-+{
-+    int n, ret;
-+    struct addrinfo hints, *addr_list, *cur;
-+
-+    if( ( ret = net_prepare() ) != 0 )
-+        return( ret );
-+
-+    /* Bind to IPv6 and/or IPv4, but only in the desired protocol */
-+    memset( &hints, 0, sizeof( hints ) );
-+    hints.ai_family = AF_UNSPEC;
-+    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
-+    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
-+    if( bind_ip == NULL )
-+        hints.ai_flags = AI_PASSIVE;
-+
-+    if( getaddrinfo( bind_ip, port, &hints, &addr_list ) != 0 )
-+        return( MBEDTLS_ERR_NET_UNKNOWN_HOST );
-+
-+    /* Try the sockaddrs until a binding succeeds */
-+    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
-+    for( cur = addr_list; cur != NULL; cur = cur->ai_next )
-+    {
-+        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
-+                            cur->ai_protocol );
-+        if( ctx->fd < 0 )
-+        {
-+            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
-+            continue;
-+        }
-+
-+        n = 1;
-+        if( setsockopt( ctx->fd, SOL_SOCKET, SO_REUSEADDR,
-+                        (const char *) &n, sizeof( n ) ) != 0 )
-+        {
-+            close( ctx->fd );
-+            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
-+            continue;
-+        }
-+
-+        if( bind( ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) != 0 )
-+        {
-+            close( ctx->fd );
-+            ret = MBEDTLS_ERR_NET_BIND_FAILED;
-+            continue;
-+        }
-+
-+        /* Listen only makes sense for TCP */
-+        if( proto == MBEDTLS_NET_PROTO_TCP )
-+        {
-+            if( listen( ctx->fd, MBEDTLS_NET_LISTEN_BACKLOG ) != 0 )
-+            {
-+                close( ctx->fd );
-+                ret = MBEDTLS_ERR_NET_LISTEN_FAILED;
-+                continue;
-+            }
-+        }
-+
-+        /* I we ever get there, it's a success */
-+        ret = 0;
-+        break;
-+    }
-+
-+    freeaddrinfo( addr_list );
-+
-+    return( ret );
-+
-+}
-+
-+#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
-+    !defined(EFI32)
-+/*
-+ * Check if the requested operation would be blocking on a non-blocking socket
-+ * and thus 'failed' with a negative return value.
-+ */
-+static int net_would_block( const mbedtls_net_context *ctx )
-+{
-+    ((void) ctx);
-+    return( WSAGetLastError() == WSAEWOULDBLOCK );
-+}
-+#else
-+/*
-+ * Check if the requested operation would be blocking on a non-blocking socket
-+ * and thus 'failed' with a negative return value.
-+ *
-+ * Note: on a blocking socket this function always returns 0!
-+ */
-+static int net_would_block( const mbedtls_net_context *ctx )
-+{
-+    /*
-+     * Never return 'WOULD BLOCK' on a non-blocking socket
-+     */
+ /*
+  * Prepare for using the sockets interface
+  */
+ static int net_prepare( void )
+ {
+-#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
+-    !defined(EFI32)
+-    WSADATA wsaData;
+-
+-    if( wsa_init_done == 0 )
+-    {
+-        if( WSAStartup( MAKEWORD(2,0), &wsaData ) != 0 )
+-            return( MBEDTLS_ERR_NET_SOCKET_FAILED );
+-
+-        wsa_init_done = 1;
+-    }
+-#else
+-#if !defined(EFIX64) && !defined(EFI32)
+-    signal( SIGPIPE, SIG_IGN );
+-#endif
+-#endif
+     return( 0 );
+ }
+ 
+@@ -272,7 +200,7 @@ static int net_would_block( const mbedtls_net_context *ctx )
+     /*
+      * Never return 'WOULD BLOCK' on a non-blocking socket
+      */
+-    if( ( fcntl( ctx->fd, F_GETFL ) & O_NONBLOCK ) != O_NONBLOCK )
 +    if( ( fcntl( ctx->fd, F_GETFL, 0 ) & O_NONBLOCK ) != O_NONBLOCK )
-+        return( 0 );
-+
-+    switch( errno )
-+    {
-+#if defined EAGAIN
-+        case EAGAIN:
-+#endif
-+#if defined EWOULDBLOCK && EWOULDBLOCK != EAGAIN
-+        case EWOULDBLOCK:
-+#endif
-+            return( 1 );
-+    }
-+    return( 0 );
-+}
-+#endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
-+
-+/*
-+ * Accept a connection from a remote client
-+ */
-+int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
-+                        mbedtls_net_context *client_ctx,
-+                        void *client_ip, size_t buf_size, size_t *ip_len )
-+{
-+    int ret;
-+    int type;
-+
-+    struct sockaddr_storage client_addr;
-+
-+    socklen_t n = (socklen_t) sizeof( client_addr );
-+    socklen_t type_len = (socklen_t) sizeof( type );
-+
-+    /* Is this a TCP or UDP socket? */
-+    if( getsockopt( bind_ctx->fd, SOL_SOCKET, SO_TYPE,
-+                    (void *) &type, &type_len ) != 0 ||
-+        ( type != SOCK_STREAM && type != SOCK_DGRAM ) )
-+    {
-+        return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
-+    }
-+
-+    if( type == SOCK_STREAM )
-+    {
-+        /* TCP: actual accept() */
-+        ret = client_ctx->fd = (int) accept( bind_ctx->fd,
-+                                         (struct sockaddr *) &client_addr, &n );
-+    }
-+    else
-+    {
-+        /* UDP: wait for a message, but keep it in the queue */
-+        char buf[1] = { 0 };
-+
-+        ret = (int) recvfrom( bind_ctx->fd, buf, sizeof( buf ), MSG_PEEK,
-+                        (struct sockaddr *) &client_addr, &n );
-+
-+#if defined(_WIN32)
-+        if( ret == SOCKET_ERROR &&
-+            WSAGetLastError() == WSAEMSGSIZE )
-+        {
-+            /* We know buf is too small, thanks, just peeking here */
-+            ret = 0;
-+        }
-+#endif
-+    }
-+
-+    if( ret < 0 )
-+    {
-+        if( net_would_block( bind_ctx ) != 0 )
-+            return( MBEDTLS_ERR_SSL_WANT_READ );
-+
-+        return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
-+    }
-+
-+    /* UDP: hijack the listening socket to communicate with the client,
-+     * then bind a new socket to accept new connections */
-+    if( type != SOCK_STREAM )
-+    {
-+        struct sockaddr_storage local_addr;
-+        int one = 1;
-+
-+        if( connect( bind_ctx->fd, (struct sockaddr *) &client_addr, n ) != 0 )
-+            return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
-+
-+        client_ctx->fd = bind_ctx->fd;
-+        bind_ctx->fd   = -1; /* In case we exit early */
-+
-+        n = sizeof( struct sockaddr_storage );
-+        if( getsockname( client_ctx->fd,
-+                         (struct sockaddr *) &local_addr, &n ) != 0 ||
-+            ( bind_ctx->fd = (int) socket( local_addr.ss_family,
-+                                           SOCK_DGRAM, IPPROTO_UDP ) ) < 0 ||
-+            setsockopt( bind_ctx->fd, SOL_SOCKET, SO_REUSEADDR,
-+                        (const char *) &one, sizeof( one ) ) != 0 )
-+        {
-+            return( MBEDTLS_ERR_NET_SOCKET_FAILED );
-+        }
-+
-+        if( bind( bind_ctx->fd, (struct sockaddr *) &local_addr, n ) != 0 )
-+        {
-+            return( MBEDTLS_ERR_NET_BIND_FAILED );
-+        }
-+    }
-+
-+    if( client_ip != NULL )
-+    {
-+        if( client_addr.ss_family == AF_INET )
-+        {
-+            struct sockaddr_in *addr4 = (struct sockaddr_in *) &client_addr;
-+            *ip_len = sizeof( addr4->sin_addr.s_addr );
-+
-+            if( buf_size < *ip_len )
-+                return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
-+
-+            memcpy( client_ip, &addr4->sin_addr.s_addr, *ip_len );
-+        }
-+        else
-+        {
+         return( 0 );
+ 
+     switch( errno )
+@@ -301,14 +229,8 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
+ 
+     struct sockaddr_storage client_addr;
+ 
+-#if defined(__socklen_t_defined) || defined(_SOCKLEN_T) ||  \
+-    defined(_SOCKLEN_T_DECLARED) || defined(__DEFINED_socklen_t)
+     socklen_t n = (socklen_t) sizeof( client_addr );
+     socklen_t type_len = (socklen_t) sizeof( type );
+-#else
+-    int n = (int) sizeof( client_addr );
+-    int type_len = (int) sizeof( type );
+-#endif
+ 
+     /* Is this a TCP or UDP socket? */
+     if( getsockopt( bind_ctx->fd, SOL_SOCKET, SO_TYPE,
+@@ -394,6 +316,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
+         }
+         else
+         {
 +#if defined(LWIP_IPV6) && (LWIP_IPV6 == 1)
-+            struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *) &client_addr;
-+            *ip_len = sizeof( addr6->sin6_addr.s6_addr );
-+
-+            if( buf_size < *ip_len )
-+                return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
-+
-+            memcpy( client_ip, &addr6->sin6_addr.s6_addr, *ip_len);
+             struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *) &client_addr;
+             *ip_len = sizeof( addr6->sin6_addr.s6_addr );
+ 
+@@ -401,6 +324,7 @@ int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
+                 return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
+ 
+             memcpy( client_ip, &addr6->sin6_addr.s6_addr, *ip_len);
 +#endif
-+        }
-+    }
-+
-+    return( 0 );
-+}
-+
-+/*
-+ * Set the socket blocking or non-blocking
-+ */
-+int mbedtls_net_set_block( mbedtls_net_context *ctx )
-+{
-+#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
-+    !defined(EFI32)
-+    u_long n = 0;
-+    return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
-+#else
+         }
+     }
+ 
+@@ -417,7 +341,7 @@ int mbedtls_net_set_block( mbedtls_net_context *ctx )
+     u_long n = 0;
+     return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
+ #else
+-    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL ) & ~O_NONBLOCK ) );
 +    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL, 0 ) & ~O_NONBLOCK ) );
-+#endif
-+}
-+
-+int mbedtls_net_set_nonblock( mbedtls_net_context *ctx )
-+{
-+#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
-+    !defined(EFI32)
-+    u_long n = 1;
-+    return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
-+#else
+ #endif
+ }
+ 
+@@ -428,7 +352,7 @@ int mbedtls_net_set_nonblock( mbedtls_net_context *ctx )
+     u_long n = 1;
+     return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
+ #else
+-    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL ) | O_NONBLOCK ) );
 +    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL, 0 ) | O_NONBLOCK ) );
-+#endif
-+}
-+
-+/*
-+ * Portable usleep helper
-+ */
-+void mbedtls_net_usleep( unsigned long usec )
-+{
-+#if defined(_WIN32)
-+    Sleep( ( usec + 999 ) / 1000 );
-+#else
-+    struct timeval tv;
-+    tv.tv_sec  = usec / 1000000;
-+#if defined(__unix__) || defined(__unix) || \
-+    ( defined(__APPLE__) && defined(__MACH__) )
-+    tv.tv_usec = (suseconds_t) usec % 1000000;
-+#else
-+    tv.tv_usec = usec % 1000000;
-+#endif
-+    select( 0, NULL, NULL, NULL, &tv );
-+#endif
-+}
-+
-+/*
-+ * Read at most 'len' characters
-+ */
-+int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
-+{
-+    int ret;
-+    int fd = ((mbedtls_net_context *) ctx)->fd;
-+
-+    if( fd < 0 )
-+        return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
-+
-+    ret = (int) read( fd, buf, len );
-+
-+    if( ret < 0 )
-+    {
-+        if( net_would_block( ctx ) != 0 )
-+            return( MBEDTLS_ERR_SSL_WANT_READ );
-+
-+#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
-+    !defined(EFI32)
-+        if( WSAGetLastError() == WSAECONNRESET )
-+            return( MBEDTLS_ERR_NET_CONN_RESET );
-+#else
-+        if( errno == EPIPE || errno == ECONNRESET )
-+            return( MBEDTLS_ERR_NET_CONN_RESET );
-+
-+        if( errno == EINTR )
-+            return( MBEDTLS_ERR_SSL_WANT_READ );
-+#endif
-+
-+        return( MBEDTLS_ERR_NET_RECV_FAILED );
-+    }
-+
-+    return( ret );
-+}
-+
-+/*
-+ * Read at most 'len' characters, blocking for at most 'timeout' ms
-+ */
-+int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
-+                      uint32_t timeout )
-+{
-+    int ret;
-+    struct timeval tv;
-+    fd_set read_fds;
-+    int fd = ((mbedtls_net_context *) ctx)->fd;
-+
-+    if( fd < 0 )
-+        return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
-+
-+    FD_ZERO( &read_fds );
-+    FD_SET( fd, &read_fds );
-+
-+    tv.tv_sec  = timeout / 1000;
-+    tv.tv_usec = ( timeout % 1000 ) * 1000;
-+
-+    ret = select( fd + 1, &read_fds, NULL, NULL, timeout == 0 ? NULL : &tv );
-+
-+    /* Zero fds ready means we timed out */
-+    if( ret == 0 )
-+        return( MBEDTLS_ERR_SSL_TIMEOUT );
-+
-+    if( ret < 0 )
-+    {
-+#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
-+    !defined(EFI32)
-+        if( WSAGetLastError() == WSAEINTR )
-+            return( MBEDTLS_ERR_SSL_WANT_READ );
-+#else
-+        if( errno == EINTR )
-+            return( MBEDTLS_ERR_SSL_WANT_READ );
-+#endif
-+
-+        return( MBEDTLS_ERR_NET_RECV_FAILED );
-+    }
-+
-+    /* This call will not block */
-+    return( mbedtls_net_recv( ctx, buf, len ) );
-+}
-+
-+/*
-+ * Write at most 'len' characters
-+ */
-+int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
-+{
-+    int ret;
-+    int fd = ((mbedtls_net_context *) ctx)->fd;
-+
-+    if( fd < 0 )
-+        return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
-+
-+    ret = (int) write( fd, buf, len );
-+
-+    if( ret < 0 )
-+    {
-+        if( net_would_block( ctx ) != 0 )
-+            return( MBEDTLS_ERR_SSL_WANT_WRITE );
-+
-+#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
-+    !defined(EFI32)
-+        if( WSAGetLastError() == WSAECONNRESET )
-+            return( MBEDTLS_ERR_NET_CONN_RESET );
-+#else
-+        if( errno == EPIPE || errno == ECONNRESET )
-+            return( MBEDTLS_ERR_NET_CONN_RESET );
-+
-+        if( errno == EINTR )
-+            return( MBEDTLS_ERR_SSL_WANT_WRITE );
-+#endif
-+
-+        return( MBEDTLS_ERR_NET_SEND_FAILED );
-+    }
-+
-+    return( ret );
-+}
-+
-+/*
-+ * Gracefully close the connection
-+ */
-+void mbedtls_net_free( mbedtls_net_context *ctx )
-+{
-+    if( ctx->fd == -1 )
-+        return;
-+
-+    shutdown( ctx->fd, 2 );
-+    close( ctx->fd );
-+
-+    ctx->fd = -1;
-+}
-+
-+#endif /* MBEDTLS_NET_C */
+ #endif
+ }
+ 
 diff --git a/embARC/threading_alt.c b/embARC/threading_alt.c
 new file mode 100644
 index 0000000..4f830a9
@@ -951,597 +604,63 @@ index 0000000..151765d
 +#endif
 +
 +#endif /* timing.h */
-diff --git a/library/net.c b/library/net.c
-deleted file mode 100644
-index 3b78b6b..0000000
---- a/library/net.c
-+++ /dev/null
-@@ -1,580 +0,0 @@
--/*
-- *  TCP/IP or UDP/IP networking functions
-- *
-- *  Copyright (C) 2006-2015, ARM Limited, All Rights Reserved
-- *  SPDX-License-Identifier: Apache-2.0
-- *
-- *  Licensed under the Apache License, Version 2.0 (the "License"); you may
-- *  not use this file except in compliance with the License.
-- *  You may obtain a copy of the License at
-- *
-- *  http://www.apache.org/licenses/LICENSE-2.0
-- *
-- *  Unless required by applicable law or agreed to in writing, software
-- *  distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-- *  WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-- *  See the License for the specific language governing permissions and
-- *  limitations under the License.
-- *
-- *  This file is part of mbed TLS (https://tls.mbed.org)
-- */
--
--#if !defined(MBEDTLS_CONFIG_FILE)
--#include "mbedtls/config.h"
--#else
--#include MBEDTLS_CONFIG_FILE
--#endif
--
--#if defined(MBEDTLS_NET_C)
--
--#if !defined(unix) && !defined(__unix__) && !defined(__unix) && \
--    !defined(__APPLE__) && !defined(_WIN32)
--#error "This module only works on Unix and Windows, see MBEDTLS_NET_C in config.h"
--#endif
--
--#include "mbedtls/net.h"
--
--#include <string.h>
--
--#if (defined(_WIN32) || defined(_WIN32_WCE)) && !defined(EFIX64) && \
--    !defined(EFI32)
--
--#ifdef _WIN32_WINNT
--#undef _WIN32_WINNT
--#endif
--/* Enables getaddrinfo() & Co */
--#define _WIN32_WINNT 0x0501
--#include <ws2tcpip.h>
--
--#include <winsock2.h>
--#include <windows.h>
--
--#if defined(_MSC_VER)
--#if defined(_WIN32_WCE)
--#pragma comment( lib, "ws2.lib" )
--#else
--#pragma comment( lib, "ws2_32.lib" )
--#endif
--#endif /* _MSC_VER */
--
--#define read(fd,buf,len)        recv(fd,(char*)buf,(int) len,0)
--#define write(fd,buf,len)       send(fd,(char*)buf,(int) len,0)
--#define close(fd)               closesocket(fd)
--
--static int wsa_init_done = 0;
--
--#else /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
--
--#include <sys/types.h>
--#include <sys/socket.h>
--#include <netinet/in.h>
--#include <arpa/inet.h>
--#include <sys/time.h>
--#include <unistd.h>
--#include <signal.h>
--#include <fcntl.h>
--#include <netdb.h>
--#include <errno.h>
--
--#endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
--
--/* Some MS functions want int and MSVC warns if we pass size_t,
-- * but the standard fucntions use socklen_t, so cast only for MSVC */
--#if defined(_MSC_VER)
--#define MSVC_INT_CAST   (int)
--#else
--#define MSVC_INT_CAST
--#endif
--
--#include <stdlib.h>
--#include <stdio.h>
--
--#include <time.h>
--
--#include <stdint.h>
--
--/*
-- * Prepare for using the sockets interface
-- */
--static int net_prepare( void )
--{
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--    WSADATA wsaData;
--
--    if( wsa_init_done == 0 )
--    {
--        if( WSAStartup( MAKEWORD(2,0), &wsaData ) != 0 )
--            return( MBEDTLS_ERR_NET_SOCKET_FAILED );
--
--        wsa_init_done = 1;
--    }
--#else
--#if !defined(EFIX64) && !defined(EFI32)
--    signal( SIGPIPE, SIG_IGN );
--#endif
--#endif
--    return( 0 );
--}
--
--/*
-- * Initialize a context
-- */
--void mbedtls_net_init( mbedtls_net_context *ctx )
--{
--    ctx->fd = -1;
--}
--
--/*
-- * Initiate a TCP connection with host:port and the given protocol
-- */
--int mbedtls_net_connect( mbedtls_net_context *ctx, const char *host, const char *port, int proto )
--{
--    int ret;
--    struct addrinfo hints, *addr_list, *cur;
--
--    if( ( ret = net_prepare() ) != 0 )
--        return( ret );
--
--    /* Do name resolution with both IPv6 and IPv4 */
--    memset( &hints, 0, sizeof( hints ) );
--    hints.ai_family = AF_UNSPEC;
--    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
--    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
--
--    if( getaddrinfo( host, port, &hints, &addr_list ) != 0 )
--        return( MBEDTLS_ERR_NET_UNKNOWN_HOST );
--
--    /* Try the sockaddrs until a connection succeeds */
--    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
--    for( cur = addr_list; cur != NULL; cur = cur->ai_next )
--    {
--        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
--                            cur->ai_protocol );
--        if( ctx->fd < 0 )
--        {
--            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
--            continue;
--        }
--
--        if( connect( ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) == 0 )
--        {
--            ret = 0;
--            break;
--        }
--
--        close( ctx->fd );
--        ret = MBEDTLS_ERR_NET_CONNECT_FAILED;
--    }
--
--    freeaddrinfo( addr_list );
--
--    return( ret );
--}
--
--/*
-- * Create a listening socket on bind_ip:port
-- */
--int mbedtls_net_bind( mbedtls_net_context *ctx, const char *bind_ip, const char *port, int proto )
--{
--    int n, ret;
--    struct addrinfo hints, *addr_list, *cur;
--
--    if( ( ret = net_prepare() ) != 0 )
--        return( ret );
--
--    /* Bind to IPv6 and/or IPv4, but only in the desired protocol */
--    memset( &hints, 0, sizeof( hints ) );
--    hints.ai_family = AF_UNSPEC;
--    hints.ai_socktype = proto == MBEDTLS_NET_PROTO_UDP ? SOCK_DGRAM : SOCK_STREAM;
--    hints.ai_protocol = proto == MBEDTLS_NET_PROTO_UDP ? IPPROTO_UDP : IPPROTO_TCP;
--    if( bind_ip == NULL )
--        hints.ai_flags = AI_PASSIVE;
--
--    if( getaddrinfo( bind_ip, port, &hints, &addr_list ) != 0 )
--        return( MBEDTLS_ERR_NET_UNKNOWN_HOST );
--
--    /* Try the sockaddrs until a binding succeeds */
--    ret = MBEDTLS_ERR_NET_UNKNOWN_HOST;
--    for( cur = addr_list; cur != NULL; cur = cur->ai_next )
--    {
--        ctx->fd = (int) socket( cur->ai_family, cur->ai_socktype,
--                            cur->ai_protocol );
--        if( ctx->fd < 0 )
--        {
--            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
--            continue;
--        }
--
--        n = 1;
--        if( setsockopt( ctx->fd, SOL_SOCKET, SO_REUSEADDR,
--                        (const char *) &n, sizeof( n ) ) != 0 )
--        {
--            close( ctx->fd );
--            ret = MBEDTLS_ERR_NET_SOCKET_FAILED;
--            continue;
--        }
--
--        if( bind( ctx->fd, cur->ai_addr, MSVC_INT_CAST cur->ai_addrlen ) != 0 )
--        {
--            close( ctx->fd );
--            ret = MBEDTLS_ERR_NET_BIND_FAILED;
--            continue;
--        }
--
--        /* Listen only makes sense for TCP */
--        if( proto == MBEDTLS_NET_PROTO_TCP )
--        {
--            if( listen( ctx->fd, MBEDTLS_NET_LISTEN_BACKLOG ) != 0 )
--            {
--                close( ctx->fd );
--                ret = MBEDTLS_ERR_NET_LISTEN_FAILED;
--                continue;
--            }
--        }
--
--        /* I we ever get there, it's a success */
--        ret = 0;
--        break;
--    }
--
--    freeaddrinfo( addr_list );
--
--    return( ret );
--
--}
--
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--/*
-- * Check if the requested operation would be blocking on a non-blocking socket
-- * and thus 'failed' with a negative return value.
-- */
--static int net_would_block( const mbedtls_net_context *ctx )
--{
--    ((void) ctx);
--    return( WSAGetLastError() == WSAEWOULDBLOCK );
--}
--#else
--/*
-- * Check if the requested operation would be blocking on a non-blocking socket
-- * and thus 'failed' with a negative return value.
-- *
-- * Note: on a blocking socket this function always returns 0!
-- */
--static int net_would_block( const mbedtls_net_context *ctx )
--{
--    /*
--     * Never return 'WOULD BLOCK' on a non-blocking socket
--     */
--    if( ( fcntl( ctx->fd, F_GETFL ) & O_NONBLOCK ) != O_NONBLOCK )
--        return( 0 );
--
--    switch( errno )
--    {
--#if defined EAGAIN
--        case EAGAIN:
--#endif
--#if defined EWOULDBLOCK && EWOULDBLOCK != EAGAIN
--        case EWOULDBLOCK:
--#endif
--            return( 1 );
--    }
--    return( 0 );
--}
--#endif /* ( _WIN32 || _WIN32_WCE ) && !EFIX64 && !EFI32 */
--
--/*
-- * Accept a connection from a remote client
-- */
--int mbedtls_net_accept( mbedtls_net_context *bind_ctx,
--                        mbedtls_net_context *client_ctx,
--                        void *client_ip, size_t buf_size, size_t *ip_len )
--{
--    int ret;
--    int type;
--
--    struct sockaddr_storage client_addr;
--
--#if defined(__socklen_t_defined) || defined(_SOCKLEN_T) ||  \
--    defined(_SOCKLEN_T_DECLARED) || defined(__DEFINED_socklen_t)
--    socklen_t n = (socklen_t) sizeof( client_addr );
--    socklen_t type_len = (socklen_t) sizeof( type );
--#else
--    int n = (int) sizeof( client_addr );
--    int type_len = (int) sizeof( type );
--#endif
--
--    /* Is this a TCP or UDP socket? */
--    if( getsockopt( bind_ctx->fd, SOL_SOCKET, SO_TYPE,
--                    (void *) &type, &type_len ) != 0 ||
--        ( type != SOCK_STREAM && type != SOCK_DGRAM ) )
--    {
--        return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
--    }
--
--    if( type == SOCK_STREAM )
--    {
--        /* TCP: actual accept() */
--        ret = client_ctx->fd = (int) accept( bind_ctx->fd,
--                                         (struct sockaddr *) &client_addr, &n );
--    }
--    else
--    {
--        /* UDP: wait for a message, but keep it in the queue */
--        char buf[1] = { 0 };
--
--        ret = (int) recvfrom( bind_ctx->fd, buf, sizeof( buf ), MSG_PEEK,
--                        (struct sockaddr *) &client_addr, &n );
--
--#if defined(_WIN32)
--        if( ret == SOCKET_ERROR &&
--            WSAGetLastError() == WSAEMSGSIZE )
--        {
--            /* We know buf is too small, thanks, just peeking here */
--            ret = 0;
--        }
--#endif
--    }
--
--    if( ret < 0 )
--    {
--        if( net_would_block( bind_ctx ) != 0 )
--            return( MBEDTLS_ERR_SSL_WANT_READ );
--
--        return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
--    }
--
--    /* UDP: hijack the listening socket to communicate with the client,
--     * then bind a new socket to accept new connections */
--    if( type != SOCK_STREAM )
--    {
--        struct sockaddr_storage local_addr;
--        int one = 1;
--
--        if( connect( bind_ctx->fd, (struct sockaddr *) &client_addr, n ) != 0 )
--            return( MBEDTLS_ERR_NET_ACCEPT_FAILED );
--
--        client_ctx->fd = bind_ctx->fd;
--        bind_ctx->fd   = -1; /* In case we exit early */
--
--        n = sizeof( struct sockaddr_storage );
--        if( getsockname( client_ctx->fd,
--                         (struct sockaddr *) &local_addr, &n ) != 0 ||
--            ( bind_ctx->fd = (int) socket( local_addr.ss_family,
--                                           SOCK_DGRAM, IPPROTO_UDP ) ) < 0 ||
--            setsockopt( bind_ctx->fd, SOL_SOCKET, SO_REUSEADDR,
--                        (const char *) &one, sizeof( one ) ) != 0 )
--        {
--            return( MBEDTLS_ERR_NET_SOCKET_FAILED );
--        }
--
--        if( bind( bind_ctx->fd, (struct sockaddr *) &local_addr, n ) != 0 )
--        {
--            return( MBEDTLS_ERR_NET_BIND_FAILED );
--        }
--    }
--
--    if( client_ip != NULL )
--    {
--        if( client_addr.ss_family == AF_INET )
--        {
--            struct sockaddr_in *addr4 = (struct sockaddr_in *) &client_addr;
--            *ip_len = sizeof( addr4->sin_addr.s_addr );
--
--            if( buf_size < *ip_len )
--                return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
--
--            memcpy( client_ip, &addr4->sin_addr.s_addr, *ip_len );
--        }
--        else
--        {
--            struct sockaddr_in6 *addr6 = (struct sockaddr_in6 *) &client_addr;
--            *ip_len = sizeof( addr6->sin6_addr.s6_addr );
--
--            if( buf_size < *ip_len )
--                return( MBEDTLS_ERR_NET_BUFFER_TOO_SMALL );
--
--            memcpy( client_ip, &addr6->sin6_addr.s6_addr, *ip_len);
--        }
--    }
--
--    return( 0 );
--}
--
--/*
-- * Set the socket blocking or non-blocking
-- */
--int mbedtls_net_set_block( mbedtls_net_context *ctx )
--{
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--    u_long n = 0;
--    return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
--#else
--    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL ) & ~O_NONBLOCK ) );
--#endif
--}
--
--int mbedtls_net_set_nonblock( mbedtls_net_context *ctx )
--{
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--    u_long n = 1;
--    return( ioctlsocket( ctx->fd, FIONBIO, &n ) );
--#else
--    return( fcntl( ctx->fd, F_SETFL, fcntl( ctx->fd, F_GETFL ) | O_NONBLOCK ) );
--#endif
--}
--
--/*
-- * Portable usleep helper
-- */
--void mbedtls_net_usleep( unsigned long usec )
--{
--#if defined(_WIN32)
--    Sleep( ( usec + 999 ) / 1000 );
--#else
--    struct timeval tv;
--    tv.tv_sec  = usec / 1000000;
--#if defined(__unix__) || defined(__unix) || \
--    ( defined(__APPLE__) && defined(__MACH__) )
--    tv.tv_usec = (suseconds_t) usec % 1000000;
--#else
--    tv.tv_usec = usec % 1000000;
--#endif
--    select( 0, NULL, NULL, NULL, &tv );
--#endif
--}
--
--/*
-- * Read at most 'len' characters
-- */
--int mbedtls_net_recv( void *ctx, unsigned char *buf, size_t len )
--{
--    int ret;
--    int fd = ((mbedtls_net_context *) ctx)->fd;
--
--    if( fd < 0 )
--        return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
--
--    ret = (int) read( fd, buf, len );
--
--    if( ret < 0 )
--    {
--        if( net_would_block( ctx ) != 0 )
--            return( MBEDTLS_ERR_SSL_WANT_READ );
--
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--        if( WSAGetLastError() == WSAECONNRESET )
--            return( MBEDTLS_ERR_NET_CONN_RESET );
--#else
--        if( errno == EPIPE || errno == ECONNRESET )
--            return( MBEDTLS_ERR_NET_CONN_RESET );
--
--        if( errno == EINTR )
--            return( MBEDTLS_ERR_SSL_WANT_READ );
--#endif
--
--        return( MBEDTLS_ERR_NET_RECV_FAILED );
--    }
--
--    return( ret );
--}
--
--/*
-- * Read at most 'len' characters, blocking for at most 'timeout' ms
-- */
--int mbedtls_net_recv_timeout( void *ctx, unsigned char *buf, size_t len,
--                      uint32_t timeout )
--{
--    int ret;
--    struct timeval tv;
--    fd_set read_fds;
--    int fd = ((mbedtls_net_context *) ctx)->fd;
--
--    if( fd < 0 )
--        return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
--
--    FD_ZERO( &read_fds );
--    FD_SET( fd, &read_fds );
--
--    tv.tv_sec  = timeout / 1000;
--    tv.tv_usec = ( timeout % 1000 ) * 1000;
--
--    ret = select( fd + 1, &read_fds, NULL, NULL, timeout == 0 ? NULL : &tv );
--
--    /* Zero fds ready means we timed out */
--    if( ret == 0 )
--        return( MBEDTLS_ERR_SSL_TIMEOUT );
--
--    if( ret < 0 )
--    {
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--        if( WSAGetLastError() == WSAEINTR )
--            return( MBEDTLS_ERR_SSL_WANT_READ );
--#else
--        if( errno == EINTR )
--            return( MBEDTLS_ERR_SSL_WANT_READ );
--#endif
--
--        return( MBEDTLS_ERR_NET_RECV_FAILED );
--    }
--
--    /* This call will not block */
--    return( mbedtls_net_recv( ctx, buf, len ) );
--}
--
--/*
-- * Write at most 'len' characters
-- */
--int mbedtls_net_send( void *ctx, const unsigned char *buf, size_t len )
--{
--    int ret;
--    int fd = ((mbedtls_net_context *) ctx)->fd;
--
--    if( fd < 0 )
--        return( MBEDTLS_ERR_NET_INVALID_CONTEXT );
--
--    ret = (int) write( fd, buf, len );
--
--    if( ret < 0 )
--    {
--        if( net_would_block( ctx ) != 0 )
--            return( MBEDTLS_ERR_SSL_WANT_WRITE );
--
--#if ( defined(_WIN32) || defined(_WIN32_WCE) ) && !defined(EFIX64) && \
--    !defined(EFI32)
--        if( WSAGetLastError() == WSAECONNRESET )
--            return( MBEDTLS_ERR_NET_CONN_RESET );
--#else
--        if( errno == EPIPE || errno == ECONNRESET )
--            return( MBEDTLS_ERR_NET_CONN_RESET );
--
--        if( errno == EINTR )
--            return( MBEDTLS_ERR_SSL_WANT_WRITE );
--#endif
--
--        return( MBEDTLS_ERR_NET_SEND_FAILED );
--    }
--
--    return( ret );
--}
--
--/*
-- * Gracefully close the connection
-- */
--void mbedtls_net_free( mbedtls_net_context *ctx )
--{
--    if( ctx->fd == -1 )
--        return;
--
--    shutdown( ctx->fd, 2 );
--    close( ctx->fd );
--
--    ctx->fd = -1;
--}
--
--#endif /* MBEDTLS_NET_C */
+diff --git a/library/ssl_srv.c b/library/ssl_srv.c
+index fc0d2d7..b5ea02c 100644
+--- a/library/ssl_srv.c
++++ b/library/ssl_srv.c
+@@ -3016,6 +3016,8 @@ curve_matching_done:
+ #endif /* MBEDTLS_KEY_EXCHANGE_DHE_RSA_ENABLED) ||
+           MBEDTLS_KEY_EXCHANGE_ECDHE_RSA_ENABLED ||
+           MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED */
++    // mask dead store of p
++    (void)p;
+ 
+     ssl->out_msglen  = 4 + n;
+     ssl->out_msgtype = MBEDTLS_SSL_MSG_HANDSHAKE;
+diff --git a/library/ssl_tls.c b/library/ssl_tls.c
+index 84a04ae..2153c80 100644
+--- a/library/ssl_tls.c
++++ b/library/ssl_tls.c
+@@ -3608,6 +3608,24 @@ static int ssl_parse_record_header( mbedtls_ssl_context *ssl )
+                                         "expected %d, received %d",
+                                         ssl->in_epoch, rec_epoch ) );
+ 
++#if defined(MBEDTLS_SSL_SRV_C)
++            /*
++             * Check for an epoch 0 Change Cipher Spec retransmission.
++             */
++            if( ssl->conf->endpoint == MBEDTLS_SSL_IS_SERVER &&
++                ssl->state == MBEDTLS_SSL_HANDSHAKE_OVER &&
++                rec_epoch == 0 &&
++                ssl->in_epoch == 1 &&
++                ssl->in_msgtype == MBEDTLS_SSL_MSG_HANDSHAKE &&
++                ssl->in_left > 13 &&
++                ssl->in_buf[13] == MBEDTLS_SSL_HS_CLIENT_KEY_EXCHANGE )
++            {
++                MBEDTLS_SSL_DEBUG_MSG( 1, ( "possible Client Key Exchange "
++                                            "retransmission" ) );
++                return( mbedtls_ssl_resend( ssl ) );
++            }
++#endif
++
+ #if defined(MBEDTLS_SSL_DTLS_CLIENT_PORT_REUSE) && defined(MBEDTLS_SSL_SRV_C)
+             /*
+              * Check for an epoch 0 ClientHello. We can't use in_msg here to
+@@ -3737,7 +3755,8 @@ int mbedtls_ssl_read_record( mbedtls_ssl_context *ssl )
+ 
+         ret = mbedtls_ssl_handle_message_type( ssl );
+ 
+-    } while( MBEDTLS_ERR_SSL_NON_FATAL == ret );
++    } while( MBEDTLS_ERR_SSL_NON_FATAL == ret ||
++             ( MBEDTLS_ERR_SSL_WANT_READ == ret && ssl->in_msglen ) );
+ 
+     if( 0 != ret )
+     {
 diff --git a/library/threading.c b/library/threading.c
-index 1b6d9cd..b2f1074 100644
+index 83ec01a..92ae7ee 100644
 --- a/library/threading.c
 +++ b/library/threading.c
-@@ -81,6 +81,16 @@ int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_unl
+@@ -82,6 +82,16 @@ int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_unl
  #endif /* MBEDTLS_THREADING_PTHREAD */
  
  #if defined(MBEDTLS_THREADING_ALT)
@@ -1558,7 +677,7 @@ index 1b6d9cd..b2f1074 100644
  static int threading_mutex_fail( mbedtls_threading_mutex_t *mutex )
  {
      ((void) mutex );
-@@ -96,6 +106,7 @@ void (*mbedtls_mutex_init)( mbedtls_threading_mutex_t * ) = threading_mutex_dumm
+@@ -97,6 +107,7 @@ void (*mbedtls_mutex_init)( mbedtls_threading_mutex_t * ) = threading_mutex_dumm
  void (*mbedtls_mutex_free)( mbedtls_threading_mutex_t * ) = threading_mutex_dummy;
  int (*mbedtls_mutex_lock)( mbedtls_threading_mutex_t * ) = threading_mutex_fail;
  int (*mbedtls_mutex_unlock)( mbedtls_threading_mutex_t * ) = threading_mutex_fail;
@@ -1567,5 +686,5 @@ index 1b6d9cd..b2f1074 100644
  /*
   * Set functions pointers and initialize global mutexes
 -- 
-2.1.4
+2.13.2.windows.1
 

--- a/middleware/mbedtls/apply_embARC_patch.sh
+++ b/middleware/mbedtls/apply_embARC_patch.sh
@@ -2,7 +2,7 @@
 
 ## REPO CONFIGURATION
 REPO_LINK="https://github.com/ARMmbed/mbedtls.git"
-REPO_COMMIT="yotta-2.3.0"
+REPO_COMMIT="mbedtls-2.4.1"
 SRC_DIRS="library,include"
 
 PREV_DIR=$(pwd)


### PR DESCRIPTION
# Summary
- Update mbedtls (yotta-2.3.0) to mbedtls-2.4.1.
- For supporting OpenThread stack.

# ToDos
-  Update mbedtls patch to mbedtls-2.4.1.
-  Update the shell script for mbedtls patch, apply_embARC_patch.sh.

# User Manual
Click and run the shell script, apply_embARC_patch.sh.