### PR TITLE
Add coap server example support for IOTDK

### DIFF
--- a/device/peripheral/sensor/temperature/adt7420/adt7420.c
+++ b/device/peripheral/sensor/temperature/adt7420/adt7420.c
@@ -163,7 +163,7 @@ int32_t adt7420_sensor_init(ADT7420_DEF_PTR obj)
 	dbg_printf(DBG_MORE_INFO, "[%s]%d: iic_obj 0x%x -> 0x%x\r\n", __FUNCTION__, __LINE__, iic_obj, *iic_obj);
 	ADT7420_CHECK_EXP_NORTN(iic_obj!=NULL);
 
-	ercd = iic_obj->iic_open(DEV_MASTER_MODE, IIC_SPEED_HIGH);
+	ercd = iic_obj->iic_open(DEV_MASTER_MODE, IIC_SPEED_FAST);
 	if ((ercd == E_OK) || (ercd == E_OPNED)) {
 		ercd = iic_obj->iic_control(IIC_CMD_MST_SET_TAR_ADDR, CONV2VOID(obj->slvaddr));
 		/** Set to Default resolution and op_mode*/

--- a/device/peripheral/sensor/temperature/tcn75/tcn75.c
+++ b/device/peripheral/sensor/temperature/tcn75/tcn75.c
@@ -146,7 +146,7 @@ int32_t tcn75_sensor_init(TCN75_DEF_PTR obj)
 	dbg_printf(DBG_MORE_INFO, "[%s]%d: iic_obj 0x%x -> 0x%x\r\n", __FUNCTION__, __LINE__, iic_obj, *iic_obj);
 	TCN75_CHECK_EXP_NORTN(iic_obj!=NULL);
 
-	ercd = iic_obj->iic_open(DEV_MASTER_MODE, IIC_SPEED_HIGH);
+	ercd = iic_obj->iic_open(DEV_MASTER_MODE, IIC_SPEED_FAST);
 	if ((ercd == E_OK) || (ercd == E_OPNED)) {
 		ercd = iic_obj->iic_control(IIC_CMD_MST_SET_TAR_ADDR, CONV2VOID(obj->slvaddr));
 		/** Set to Default op_mode*/

--- a/example/freertos/iot/coap/coap_server/FreeRTOSConfig.h
+++ b/example/freertos/iot/coap/coap_server/FreeRTOSConfig.h
@@ -86,7 +86,7 @@
 #define configTICK_RATE_HZ                      ( ( TickType_t ) 1000 )
 #define configMAX_PRIORITIES                    ( 10 )
 #define configMINIMAL_STACK_SIZE                ( ( unsigned short ) 104 )
-#define configTOTAL_HEAP_SIZE                   ( ( size_t ) ( 256 * 1024 ) )
+#define configTOTAL_HEAP_SIZE                   ( ( size_t ) ( 50 * 1024 ) )
 #define configMAX_TASK_NAME_LEN                 ( 10 )
 #define configUSE_TRACE_FACILITY                0
 #define configUSE_16_BIT_TICKS                  0

--- a/example/freertos/iot/coap/coap_server/lwipopts.h
+++ b/example/freertos/iot/coap/coap_server/lwipopts.h
@@ -72,7 +72,7 @@
  * MEM_SIZE: the size of the heap memory. If the application will send
  * a lot of data that needs to be copied, this should be set high.
  */
-#define MEM_SIZE                        (20*1024)
+#define MEM_SIZE                        (10*1024)
 
 
 /*
@@ -87,7 +87,7 @@
  * If the application sends a lot of data out of ROM (or other static memory),
  * this should be set high.
  */
-#define MEMP_NUM_PBUF                   50
+#define MEMP_NUM_PBUF                   20
 
 /**
  * MEMP_NUM_RAW_PCB: Number of raw connection PCBs
@@ -162,7 +162,7 @@
 /**
  * PBUF_POOL_SIZE: the number of buffers in the pbuf pool.
  */
-#define PBUF_POOL_SIZE                  120
+#define PBUF_POOL_SIZE                  50
 
 /*
    ---------------------------------


### PR DESCRIPTION
# Summary
- Optimized RAM usage of coap server example
- Found and fixed an speed mismatch of temperature sensor during the test of coap server example with IOTDK


# ToDos
- Other examples need ntshell support