### PR TITLE
fix typo in embARC middleware documentation

### DIFF
--- a/doc/documents/middleware/middleware.rst
+++ b/doc/documents/middleware/middleware.rst
@@ -1,6 +1,6 @@
 .. _middleware_layer:
 
-Middlwares
+Middlewares
 ==========
 
 Overview


### PR DESCRIPTION
# Summary
- This typo located [here](https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_osp/blob/master/doc/documents/middleware/middleware.rst#middlwares).

# Changes
I have fixed the typos directly in this file, please check.