### PR TITLE
travis: send wrong build results as comment to github when pull requests

### DIFF
--- a/.ci/before_install.sh
+++ b/.ci/before_install.sh
@@ -29,4 +29,5 @@ fi
     pip install PrettyTable || die
     pip install colorama || die
     pip install configparser || die
+    pip install requests || die
 }

--- a/.ci/build.py
+++ b/.ci/build.py
@@ -2,6 +2,7 @@
 import json
 import os
 import sys
+import requests
 from prettytable import PrettyTable
 from colorama import Fore, Back, Style
 from configparser import ConfigParser
@@ -374,14 +375,30 @@ def get_expected_result(expected_file, app_path, board, bd_ver):
     return result
 
 
+def send_pull_request_comment(columns, results):
+    if len(results)>0:
+        head = "|".join(columns) + "\n"
+        table_format =  "|".join(["---"]*len(columns)) + "\n"
+        table_head =head +table_format
+        comments = ""
+        comment = ""
+        for result in results:
+            for k in result:
+                comment += (k.replace(Fore.RED, "")).replace("\n", "<br>") +" |"
+            comment = comment.rstrip("|") + "\n"
+            comments += comment
+        comment_on_pull_request(table_head + comments)
+
+
 def show_results(results, expected=None):
-    columns = ['TOOLCHAIN', 'APP', "TOOLCHAIN_VER", 'CONF', 'PASS']
+    columns = ["TOOLCHAIN_VER", 'TOOLCHAIN', 'APP', 'CONF', 'PASS']
     failed_pt = PrettyTable(columns)
     failed_results = []
     success_results = []
     expected_results = None
     success_pt = PrettyTable(columns)
     expected_pt = PrettyTable(columns)
+    
     for result in results:
         status = result.pop("status")
         if status != 0:
@@ -398,6 +415,7 @@ def show_results(results, expected=None):
 
     if expected is not None:
         expected_results = failed_results
+        send_pull_request_comment(columns, expected_results)
         for result in expected_results:
             if len(result) > 0:
                 expected_pt.add_row(result)
@@ -413,6 +431,8 @@ def show_results(results, expected=None):
                 success_pt.add_row(result)
         print Fore.GREEN + "Successfull results"
         print success_pt
+        
+        
         print Style.RESET_ALL
         sys.stdout.flush()
 
@@ -427,6 +447,7 @@ def show_results(results, expected=None):
 
         print Fore.RED + "Failed result:"
         print failed_pt
+        
         print Style.RESET_ALL
         sys.stdout.flush()
 
@@ -529,12 +550,24 @@ def build_makefiles_project(config):
             diff_expected_differents[app_path] = copy.deepcopy(expected_different[app_path])
 
     print "There are {} projects, and they are compiled for {} times".format(app_count, count)
-    results_list = build_result_combine_tail(apps_results)
+    results_list = copy.deepcopy(build_result_combine_tail(apps_results))
     show_results(results_list)
     expected_differents_list = build_result_combine_tail(diff_expected_differents)
     show_results(expected_differents_list, expected=True)
 
     return applications_failed, diff_expected_differents
+
+
+def comment_on_pull_request(comment):
+    pr_number = os.environ.get("TRAVIS_PULL_REQUEST")
+    slug =  os.environ.get("TRAVIS_REPO_SLUG")
+    token = os.environ.get("GH_TOKEN")
+    if all([pr_number, slug, token, comment]):
+        url = 'https://api.github.com/repos/{slug}/issues/{number}/comments'.format(
+            slug=slug, number=pr_number)
+        response = requests.post(url, data=json.dumps({'body': comment}),
+            headers={'Authorization': 'token ' + token})
+        return response.json()
 
 
 def get_options_parser():
@@ -590,4 +623,6 @@ if __name__ == '__main__':
     else:
         print "these applications failed with some configuration: "
         print expected_differents.keys()
+        comment = "applications failed with some configuration: \n" + "\n".join(expected_differents.keys())
+        comment_on_pull_request(comment)
         sys.exit(1)

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -25,12 +25,23 @@ make html &> build_html.log || { tail -n 100 build_html.log ; die "Build sphinx 
 # Check if this is a pull request
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     echo "Don't push built docs to gh-pages for pull request "
-    COMMENT=$(make linkcheck 2>&1)
-    COMMENT="make checkline \n\n${COMMENT}"
+    make linkcheck 2>&1 > make.log
+    cat make.log | while read line; do
+        COMMENT_CONTENT=`"$line"`
+    done
+    COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
+    COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
     bash -c "$COMMENTS"
     exit 0
 fi
-
+make linkcheck 2>&1 > make.log
+cat make.log | while read line; do
+    COMMENT_CONTENT=`"$line"`
+done
+COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
+COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
+bash -c "$COMMENTS"
+exit 0
 # Check if this is master branch
 # Only push doc changes to gh-pages when this is master branch
 if [ "$TRAVIS_BRANCH" != "master" ] ; then

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -34,12 +34,14 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     bash -c "$COMMENTS"
     exit 0
 fi
+COMMENT_CONTENT=""
 make linkcheck 2>&1 > make.log
 cat make.log | while read line; do
-    COMMENT=`"$line"`
+    COMMENT_CONTENT="${COMMENT_HEAD}\n${line}"
 done
 COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
-# COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
+COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
+echo $COMMENT
 bash -c "$COMMENTS"
 exit 0
 # Check if this is master branch

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -37,8 +37,8 @@ fi
 
 make linkcheck 2>&1 > make.log
 COMMENT_CONTENT=$(cat make.txt)
-COMMENT_HEAD="# embarc_osp link check result<br>***********************<br>"
-COMMENT=${COMMENT_HEAD}"${COMMENT_CONTENT}"
+COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
+COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
 
 bash -c "$COMMENTS"
 exit 0

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -34,14 +34,12 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     bash -c "$COMMENTS"
     exit 0
 fi
-COMMENT_CONTENT=""
+
 make linkcheck 2>&1 > make.log
-cat make.log | while read line; do
-    COMMENT_CONTENT="${COMMENT_HEAD}\n${line}"
-done
-COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
-COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
-echo $COMMENT
+COMMENT_CONTENT=$(cat make.txt)
+COMMENT_HEAD="# embarc_osp link check result<br>***********************<br>"
+COMMENT=${COMMENT_HEAD}"${COMMENT_CONTENT}"
+
 bash -c "$COMMENTS"
 exit 0
 # Check if this is master branch

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -25,6 +25,9 @@ make html &> build_html.log || { tail -n 100 build_html.log ; die "Build sphinx 
 # Check if this is a pull request
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
     echo "Don't push built docs to gh-pages for pull request "
+    COMMENT=$(make linkcheck 2>&1)
+    COMMENT="make checkline \n\n${COMMENT}"
+    bash -c "$COMMENTS"
     exit 0
 fi
 

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -36,7 +36,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
 fi
 
 make linkcheck 2>&1 > make.log
-COMMENT_CONTENT=$(cat make.log)
+COMMENT_CONTENT=$(sed 's/$/&<br>/g' make.log)
 COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
 COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
 

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -30,7 +30,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
         COMMENT_CONTENT=`"$line"`
     done
     COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
-    COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
+    COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
     bash -c "$COMMENTS"
     exit 0
 fi
@@ -39,7 +39,7 @@ cat make.log | while read line; do
     COMMENT_CONTENT=`"$line"`
 done
 COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
-COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
+COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
 bash -c "$COMMENTS"
 exit 0
 # Check if this is master branch

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -36,10 +36,10 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
 fi
 make linkcheck 2>&1 > make.log
 cat make.log | while read line; do
-    COMMENT_CONTENT=`"$line"`
+    COMMENT=`"$line"`
 done
 COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
-COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
+# COMMENT=${COMMENT_HEAD}${COMMENT_CONTENT}
 bash -c "$COMMENTS"
 exit 0
 # Check if this is master branch

--- a/.ci/deploy_doc.sh
+++ b/.ci/deploy_doc.sh
@@ -36,7 +36,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
 fi
 
 make linkcheck 2>&1 > make.log
-COMMENT_CONTENT=$(cat make.txt)
+COMMENT_CONTENT=$(cat make.log)
 COMMENT_HEAD="# embarc_osp link check result\n***********************\n"
 COMMENT="${COMMENT_HEAD}${COMMENT_CONTENT}"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,13 @@ env:
       "context": "travis-ci/$NAME",
       "target_url": "https://travis-ci.org/$TRAVIS_REPO_SLUG/jobs/$TRAVIS_JOB_ID"
       }\nDATA'
+      
+      COMMENT=none
+      COMMENTS=$'curl -so/dev/null --user "$EMBARC_BOT" --request POST
+      https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/comments
+      --data @- << DATA\n{
+      "body": "$COMMENT"
+      }\nDATA'
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ env:
       
       COMMENT=none
       COMMENTS=$'curl -so/dev/null --user "$EMBARC_BOT" --request POST
-      https://api.github.com/repos/$TRAVIS_REPO_SLUG/issues/$TRAVIS_PULL_REQUEST/comments
+      https://api.github.com/repos/wangnuannuan/embarc_osp/issues/1/comments
       --data @- << DATA\n{
       "body": "$COMMENT"
       }\nDATA'
@@ -35,7 +35,7 @@ branches:
 
 before_install:
   - bash .ci/before_install.sh
-  # setup git config
+  # setup git config 
   - git config --global user.name "embARC Automated Bot"
   - git config --global user.email "Huaqi.Fang@synopsys.com"
 


### PR DESCRIPTION

# Summary
- send the result of `make linkcheck` as a comment to github.
- send wrong build results as comment to github when pull requests.

