### PR TITLE
secureshield: invalidate and flush cache after secureshield init

### DIFF
--- a/arc/arc_cache.c
+++ b/arc/arc_cache.c
@@ -412,3 +412,13 @@ void arc_cache_init(void)
 	}
 
 }
+
+/**
+ * \brief  initialize cache
+ * invalidate icache and dcache
+ */
+void arc_cache_invalidate(void)
+{
+	dcache_invalidate();
+	icache_invalidate();
+}

--- a/inc/arc/arc_cache.h
+++ b/inc/arc/arc_cache.h
@@ -309,6 +309,7 @@ extern int32_t dcache_direct_write(uint32_t cache_addr, uint32_t tag, uint32_t d
 extern int32_t dcache_direct_read(uint32_t cache_addr, uint32_t *tag, uint32_t *data);
 extern int32_t dcache_indirect_read(uint32_t mem_addr, uint32_t *tag, uint32_t *data);
 extern void arc_cache_init(void);
+extern void arc_cache_invalidate(void);
 
 #ifdef __cplusplus
 }

--- a/library/secureshield/core/src/secureshield_startup.s
+++ b/library/secureshield/core/src/secureshield_startup.s
@@ -135,6 +135,7 @@ _init_phase2:
 	j 	_exit_loop
 _next_stage:
 	jl 	secureshield_init
+	jl	arc_cache_invalidate
 
 	pop 	gp
 	pop 	blink

--- a/library/secureshield/secureshield.mk
+++ b/library/secureshield/secureshield.mk
@@ -144,8 +144,8 @@ DBG_HW_FLAGS += -ex "add-symbol-file $(SECURESHIELD_SECURE).elf _f_rom_secureshi
 endif
 endif
 
-SECURE_LIBS += $(OUT_DIR)/arc/startup/arc_cxx_support.o $(SECURE_APPL_LIBS) \
-	 	$(BOARD_LIB) $(MID_LIBS) $(OS_LIBS) $(LIB_LIB_CLIB)
+SECURE_LIBS += $(OUT_DIR)/arc/startup/arc_cxx_support.o $(OUT_DIR)/arc/arc_cache.o \
+		$(SECURE_APPL_LIBS) $(BOARD_LIB) $(MID_LIBS) $(OS_LIBS) $(LIB_LIB_CLIB)
 
 ##### SECURE  APPLICATION C/ASM/CPP SOURCE FILE COMPILING RULES#####
 .SECONDEXPANSION:


### PR DESCRIPTION
Signed-off-by: Yiping Peng <yibingp@synopsys.com>

# Summary
- when the cache is enabled, the application which runs in DDR RAM after secureshield init will cause an exception 
- the application after a secure service call won't cause an exception 
- invalidate and flush cache after secureshield init
