### PR TITLE
board: iotdk: optimization and bug fixes

### DIFF
--- a/board/iotdk/configs/10/iotdk_hardware.h
+++ b/board/iotdk/configs/10/iotdk_hardware.h
@@ -41,7 +41,7 @@
 #define BOARD_DFSS_AHB_CLK	(BOARD_DFSS_CORE_CLK)	/* iotdk top-level AHB peripherals clock as DFSS */
 #define BOARD_DFSS_APB_CLK	(BOARD_DFSS_CORE_CLK)		/* iotdk top-level APB peripherals clock as DFSS */
 #define BOARD_APB_CLK 		(BOARD_DFSS_APB_CLK)	/* iotdk top-level APB peripherals clock */
-#define BOARD_SPI_CLK		(100000000U)		/* iotdk SPI clock*/
+#define BOARD_SPI_CLK		(BOARD_DFSS_AHB_CLK)		/* iotdk SPI clock*/
 
 /* CPU clock frequency definition */
 #ifdef BOARD_DFSS_CORE_CLK

--- a/board/iotdk/drivers/flash_obj/flash_obj.c
+++ b/board/iotdk/drivers/flash_obj/flash_obj.c
@@ -42,7 +42,7 @@
 
 #if (USE_IOTDK_EFLASH)
 static DEV_FLASH iotdk_eflash_obj;
-EFLASH_DEFINE(eflash, EFLASH_CRTL_BASE);
+EFLASH_DEFINE(eflash, EFLASH_CTRL_BASE);
 
 static int32_t iotdk_eflash_open(void)
 {
@@ -205,7 +205,7 @@ static void iotdk_eflash_install(void)
 
 #if (USE_IOTDK_BOOT_SPI_FLASH)
 static DEV_FLASH iotdk_bootspi_obj;
-BOOTSPI_DEFINE(bootspi, BOOTSPI_CRTL_BASE);
+BOOTSPI_DEFINE(bootspi, BOOTSPI_CTRL_BASE);
 
 static int32_t iotdk_bootspi_open(void)
 {

--- a/middleware/ntshell/cmds/cmds_fs/cmd_flash.c
+++ b/middleware/ntshell/cmds/cmds_fs/cmd_flash.c
@@ -73,8 +73,8 @@ static int cmd_flash(int argc, char **argv, void *extobj)
 	uint32_t offset_addr = 0;
 	VALID_EXTOBJ(extobj, -1);
 	NTSHELL_IO_GET(extobj);
-	EFLASH_DEFINE(eflash_test, EFLASH_CRTL_BASE);
-	BOOTSPI_DEFINE(bootspi_test, BOOTSPI_CRTL_BASE);
+	EFLASH_DEFINE(eflash_test, EFLASH_CTRL_BASE);
+	BOOTSPI_DEFINE(bootspi_test, BOOTSPI_CTRL_BASE);
 	SMIC_EFLASH_INFO eflash_info;
 
 	if (argc == 1) {


### PR DESCRIPTION
* **optimizations**
    * smic_eflash: use malloc buffer
    * smic_bootspi: use malloc buffer, use high speed mode

* **bug fixes**
    * fix spelling mistake in flash_obj.c and cmd_flash.c
    * fix iotdk spi clock frequency

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>