### PR TITLE
arc: timer: add microsecond delay function

### DIFF
--- a/board/board.c
+++ b/board/board.c
@@ -180,6 +180,7 @@ void board_main(void)
 	board_init();
 /* board level middlware init */
 
+	timer_calibrate_delay(BOARD_CPU_CLOCK);
 
 #ifdef MID_COMMON
 	xprintf_setup();

--- a/inc/arc/arc_timer.h
+++ b/inc/arc/arc_timer.h
@@ -109,6 +109,8 @@ extern int32_t timer_stop(const uint32_t no);
 extern int32_t timer_current(const uint32_t no, void* val);
 extern int32_t timer_int_clear(const uint32_t no);
 extern void timer_init(void);
+extern void arc_delay_us(uint32_t usecs);
+extern uint64_t timer_calibrate_delay(uint32_t cpu_clock);
 extern int32_t secure_timer_present(const uint32_t no);
 extern int32_t secure_timer_start(const uint32_t no, const uint32_t mode, const uint32_t val);
 extern int32_t secure_timer_stop(const uint32_t no);


### PR DESCRIPTION
The loop count register (LP_COUNT) is used for zero delay loops,
we use it to realize accurate microsecond delay.

1. precomputed gl_loops_per_jiffy(1 ms loops count)
   in timer_calibrate_delay function,
   loops per "N" usecs = gl_loops_per_jiffy/1000.
2. use arc_delay_us(uint32_t usecs) function.

Signed-off-by: Watson Zeng <zhiwei@synopsys.com>