### PR TITLE
emsdp: remove extra component

### DIFF
--- a/board/emsdp/emsdp.mk
+++ b/board/emsdp/emsdp.mk
@@ -72,7 +72,7 @@ ifdef ONCHIP_IP_LIST
 endif
 
 # onboard device rules
-EXT_DEV_LIST += flash/w25qxx
+EXT_DEV_LIST +=
 
 include $(EMBARC_ROOT)/device/device.mk
 


### PR DESCRIPTION
flash w25qxx does not exist on emsdp

Signed-off-by: Yuguo Zou <yuguo.zou@synopsys.com>.