### PR TITLE
travis: Secureshield examples don't support nsim and iotdk

### DIFF
--- a/.ci/expected.ini
+++ b/.ci/expected.ini
@@ -37,12 +37,14 @@ emsk=23
 hsdk=
 axs=
 emsdp=
+nsim=
 
 [example/baremetal/secureshield/secret_normal]
 emsk=23
 hsdk=
 axs=
 emsdp=
+nsim=
 
 
 [example/baremetal/secureshield/test_case]
@@ -88,6 +90,8 @@ emsk=23
 hsdk=
 axs=
 emsdp=
+iotdk=
+nsim=
 
 [example/freertos/sec/mbedtls/ssl/client2]
 iotdk=


### PR DESCRIPTION
Signed-off-by: Jingru <jingru@synopsys.com>
