### PR TITLE
IP/Subsystem: Fix the I2S Tx interrupt masking issue if the requested…

### DIFF
--- a/device/ip/subsystem/i2s/i2s_tx_master.c
+++ b/device/ip/subsystem/i2s/i2s_tx_master.c
@@ -450,6 +450,14 @@ static uint32_t i2s_tx_master_write_samples(uint32_t dev_id,
         if (NULL != dev->tx_cb) {
         dev->tx_cb(dev_id);
         }
+        /* As the whole data requested by the upper 
+        layer has been sent, there is no need to keep
+        a value in *count.
+        Setting *count to zero will prevent calling
+        i2s_tx_master_write_samples again, where
+        usr_cnt will be equal to sys_cnt,
+        which will result in masking the interrupt */
+        *count = 0;
     }
     }
 


### PR DESCRIPTION
If requested data length isn't integer multiple of (FIFO - THRE), the interrupt of I2S will be masked.

Let's assume FIFO = 16, THRE = 3, and requested data length is 20 bytes.

First,` i2s_tx_master_tx_ISR_proc` will `call i2s_tx_master_write_samples` with sample_cnt = (16 - 3) = 13.
Second, `i2s_tx_master_write_samples` will update `sample_cnt` to be 0, so the loop will exit.

Upon receiving FIFO interrupt, `i2s_tx_master_tx_ISR_proc` will call `i2s_tx_master_write_samples` again with `sample_cnt = 13`.
`i2s_tx_master_write_samples` will update `sample_cnt` to be 13 - 7 (20 requested - 13 sent the previous round) = 6

`i2s_tx_master_write_samples` will find that `dev->xfr_len == *size`, so it will increment `sys_cnt` and call application callback.
`i2s_tx_master_tx_ISR_proc` will iterate one more time because `sample_cnt` didn't reach zero yet.
Now, the condition `if (dev->sys_cnt == dev->usr_cnt)` will be true, so the interrupt will be masked.