### PR TITLE
board: add openocd config files for different boards

### DIFF
--- a/board/axs/configs/103/core_debug.mk
+++ b/board/axs/configs/103/core_debug.mk
@@ -1,10 +1,10 @@
 ifeq ($(VALID_CUR_CORE),archs36)
-OPENOCD_CFG_FILE ?= $(OPENOCD_SCRIPT_ROOT)/board/snps_axs103_hs36.cfg
+OPENOCD_CFG_FILE ?= $(BOARD_CORE_DIR)/openocd/snps_axs103_hs36.cfg
 else
 ifeq ($(VALID_CUR_CORE),archs38)
-OPENOCD_CFG_FILE ?= $(OPENOCD_SCRIPT_ROOT)/board/snps_axs103_hs38.cfg
+OPENOCD_CFG_FILE ?= $(BOARD_CORE_DIR)/openocd/snps_axs103_hs38.cfg
 else
-OPENOCD_CFG_FILE ?= $(OPENOCD_SCRIPT_ROOT)/board/snps_axs103_hs36.cfg
+OPENOCD_CFG_FILE ?= $(BOARD_CORE_DIR)/openocd/snps_axs103_hs36.cfg
 endif
 endif
 

--- a/board/axs/configs/103/openocd/snps_axs103_hs36.cfg
+++ b/board/axs/configs/103/openocd/snps_axs103_hs36.cfg
@@ -1,0 +1,23 @@
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similiar to Digilent HS-1, except that
+# it uses channgel B for JTAG, instead of channel A.
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+ftdi_layout_init 0x0088 0x008b
+ftdi_channel 1
+
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
+
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_axc003_hs36.cfg]
+
+# Initialize
+init
+reset halt

--- a/board/axs/configs/103/openocd/snps_axs103_hs38.cfg
+++ b/board/axs/configs/103/openocd/snps_axs103_hs38.cfg
@@ -1,0 +1,23 @@
+# Configure JTAG cable
+# SDP has built-in FT2232 chip, which is similiar to Digilent HS-1, except that
+# it uses channgel B for JTAG, instead of channel A.
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+ftdi_layout_init 0x0088 0x008b
+ftdi_channel 1
+
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
+
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_axc003_hs38.cfg]
+
+# Initialize
+init
+reset hal

--- a/board/axs/configs/core_configs.mk
+++ b/board/axs/configs/core_configs.mk
@@ -49,7 +49,5 @@ ifneq ($(wildcard $(CORE_DEBUG_MK)),)
 COMMON_COMPILE_PREREQUISITES += $(CORE_DEBUG_MK)
 include $(CORE_DEBUG_MK)
 else
-OPENOCD_CFG_FILE ?= $(OPENOCD_SCRIPT_ROOT)/board/snps_axs103_hs36.cfg
+OPENOCD_CFG_FILE ?= $(BOARD_CORE_DIR)/openocd/snps_axs103_hs36.cfg
 endif
-
-OPENOCD_OPTIONS  = -s $(OPENOCD_SCRIPT_ROOT) -f $(OPENOCD_CFG_FILE)

--- a/board/board.mk
+++ b/board/board.mk
@@ -54,6 +54,12 @@ BOARD_ID = $(call uc,BOARD_$(VALID_BOARD))
 COMMON_COMPILE_PREREQUISITES += $(BOARDS_ROOT)/$(VALID_BOARD)/$(VALID_BOARD).mk
 include $(BOARDS_ROOT)/$(VALID_BOARD)/$(VALID_BOARD).mk
 
+ifneq ($(strip $(DIG_NUM)), )
+OPENOCD_OPTIONS  = -s $(OPENOCD_SCRIPT_ROOT) -c 'set _FTDI_SERIAL $(DIG_NUM)' -f $(OPENOCD_CFG_FILE)
+else
+OPENOCD_OPTIONS  = -s $(OPENOCD_SCRIPT_ROOT) -f $(OPENOCD_CFG_FILE)
+endif
+
 ##
 # \brief	add defines for board
 ##

--- a/board/emsdp/emsdp.mk
+++ b/board/emsdp/emsdp.mk
@@ -60,7 +60,6 @@ include $(BOARD_EMSDP_DIR)/$(VALID_BD_VER)/configs/core_compiler.mk
 
 ## Board Related Settings
 OPENOCD_CFG_FILE = $(BOARD_EMSDP_DIR)/openocd/snps_emsdp.cfg
-OPENOCD_OPTIONS  = -s $(OPENOCD_SCRIPT_ROOT) -f $(OPENOCD_CFG_FILE)
 
 
 ##

--- a/board/emsdp/openocd/snps_emsdp.cfg
+++ b/board/emsdp/openocd/snps_emsdp.cfg
@@ -24,6 +24,9 @@ ftdi_vid_pid 0x0403 0x6010
 ftdi_layout_init 0x0088 0x008b
 ftdi_channel 0
 
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
 
 adapter_khz 10000
 

--- a/board/emsk/configs/11/openocd.cfg
+++ b/board/emsk/configs/11/openocd.cfg
@@ -1,0 +1,21 @@
+# Configure JTAG cable
+# EM Starter Kit has built-in FT2232 chip, which is similiar to Digilent HS-1.
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+ftdi_layout_init 0x0088 0x008b
+
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
+
+adapter_khz 10000
+
+# ARCs support only JTAG.
+transport select jtag
+
+# Configure FPGA. This script supports both LX45 and LX150.
+source [find target/snps_em_sk_fpga.cfg]
+
+# Initialize
+init
+reset halt

--- a/board/emsk/configs/22/openocd.cfg
+++ b/board/emsk/configs/22/openocd.cfg
@@ -1,0 +1,22 @@
+# Configure JTAG cable
+# EM Starter Kit has built-in FT2232 chip, which is similiar to Digilent HS-1.
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+ftdi_layout_init 0x0088 0x008b
+
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
+
+# EM11D reportedly requires 5 MHz. Other cores and board can work faster.
+adapter_khz 5000
+
+# ARCs support only JTAG.
+transport select jtag
+
+# Configure FPGA. This script supports both LX45 and LX150.
+source [find target/snps_em_sk_fpga.cfg]
+
+# Initialize
+init
+reset halt

--- a/board/emsk/configs/23/openocd.cfg
+++ b/board/emsk/configs/23/openocd.cfg
@@ -1,0 +1,22 @@
+# Configure JTAG cable
+# EM Starter Kit has built-in FT2232 chip, which is similiar to Digilent HS-1.
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+ftdi_layout_init 0x0088 0x008b
+
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
+
+# EM11D reportedly requires 5 MHz. Other cores and board can work faster.
+adapter_khz 5000
+
+# ARCs support only JTAG.
+transport select jtag
+
+# Configure FPGA. This script supports both LX45 and LX150.
+source [find target/snps_em_sk_fpga.cfg]
+
+# Initialize
+init
+reset halt

--- a/board/emsk/emsk.mk
+++ b/board/emsk/emsk.mk
@@ -65,12 +65,7 @@ COMMON_COMPILE_PREREQUISITES += $(BOARD_EMSK_DIR)/configs/core_compiler.mk
 include $(BOARD_EMSK_DIR)/configs/core_compiler.mk
 
 ## Board Related Settings
-ifeq ($(VALID_BD_VER), 11)
-OPENOCD_CFG_FILE = $(OPENOCD_SCRIPT_ROOT)/board/snps_em_sk_v1.cfg
-else
-OPENOCD_CFG_FILE = $(OPENOCD_SCRIPT_ROOT)/board/snps_em_sk_v2.2.cfg
-endif
-OPENOCD_OPTIONS  = -s $(OPENOCD_SCRIPT_ROOT) -f $(OPENOCD_CFG_FILE)
+OPENOCD_CFG_FILE = $(BOARD_CORE_DIR)/openocd.cfg
 BOARD_EMSK_DEFINES += -DBOARD_SPI_FREQ=800000
 
 

--- a/board/hsdk/configs/openocd.cfg
+++ b/board/hsdk/configs/openocd.cfg
@@ -1,0 +1,25 @@
+# Configure JTAG cable
+# Synopsys SDP Mainboard has embdded FT2232 chip, which is similiar to Digilent
+# HS-1, except that it uses channel B for JTAG communication, instead of
+# channel A.
+
+interface ftdi
+ftdi_vid_pid 0x0403 0x6010
+ftdi_layout_init 0x0088 0x008b
+ftdi_channel 1
+
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
+
+adapter_khz 10000
+
+# ARCs supports only JTAG.
+transport select jtag
+
+# Configure SoC
+source [find target/snps_hsdk.cfg]
+
+# Initialize
+init
+reset halt

--- a/board/hsdk/hsdk.mk
+++ b/board/hsdk/hsdk.mk
@@ -54,9 +54,8 @@ COMMON_COMPILE_PREREQUISITES += $(BOARD_HSDK_DIR)/configs/core_compiler.mk
 include $(BOARD_HSDK_DIR)/configs/core_compiler.mk
 
 ## Board Related Settings
-OPENOCD_CFG_FILE = $(OPENOCD_SCRIPT_ROOT)/board/snps_hsdk.cfg
+OPENOCD_CFG_FILE = $(BOARD_HSDK_DIR)/configs/openocd.cfg
 
-OPENOCD_OPTIONS  = -s $(OPENOCD_SCRIPT_ROOT) -f $(OPENOCD_CFG_FILE)
 
 ## Build Rules
 # onchip ip object rules

--- a/board/iotdk/configs/openocd/snps_iotdk.cfg
+++ b/board/iotdk/configs/openocd/snps_iotdk.cfg
@@ -24,6 +24,9 @@ ftdi_vid_pid 0x0403 0x6010
 ftdi_layout_init 0x0088 0x008b
 ftdi_channel 1
 
+if { [info exists _FTDI_SERIAL] } {
+       ftdi_serial $_FTDI_SERIAL
+}
 
 # EM9D requires 8 MHz.
 adapter_khz 8000

--- a/board/iotdk/iotdk.mk
+++ b/board/iotdk/iotdk.mk
@@ -56,7 +56,6 @@ include $(BOARD_IOTDK_DIR)/configs/core_compiler.mk
 ## Board Related Settings, GNU is not supported
 OPENOCD_CFG_FILE ?= $(BOARD_IOTDK_DIR)/configs/openocd/snps_iotdk.cfg
 
-OPENOCD_OPTIONS ?= -s $(OPENOCD_SCRIPT_ROOT) -f $(OPENOCD_CFG_FILE)
 
 ## hardware debug options
 # debug speed config, iotdk starts as 16 Mhz, so the max jtag freq. is

--- a/options/options.mk
+++ b/options/options.mk
@@ -70,6 +70,15 @@ JTAG ?= usb
 DIG_NAME ?=
 
 ##
+# Digilent JTAG Number Specify
+# This is especially useful if you have more than one
+# Digilent device connected to your host.
+# You can open digilent adept tool to see what digilent
+# jtag is connected
+##
+DIG_NUM ?=
+
+##
 # Digilent JTAG Choice Select(Only for Metaware)
 # Simple wrapper of -prop=dig_device_choice=N option of Metaware Debugger(mdb)
 ##

--- a/options/rules.mk
+++ b/options/rules.mk
@@ -132,6 +132,7 @@ help :
 	@$(ECHO) '  SILENT=0|1                                  - Disable or enable message output'
 	@$(ECHO) '  V=0|1                                       - Disable or enable verbose compiling information'
 	@$(ECHO) '  DIG_NAME=xxx                                - Specify Digilent JTAG which to be used, most useful when more than one Digilent USB-JTAG plugged in'
+	@$(ECHO) '  DIG_NUM=xxx                                 - Specify device serial number which to be used for OpenOCD, most useful when more than one device plugged in'
 	@$(ECHO) '  HEAPSZ=xxx                                  - Specify heap size for program, xxx stands for size in bytes'
 	@$(ECHO) '  STACKSZ=xxx                                 - Specify stack size for program, xxx stands for size in bytes'
 	@$(ECHO) '  LINKER_SCRIPT_FILE=xxx                      - Specify customized linker script, xxx stands for the relative path of linker script file to current directory'


### PR DESCRIPTION
# Summary
- Add openocd config file fie each board.
- Add variable `DIG_NUM` to specify the device serial number, this is useful if you have more than one digilent device connected to your host. 

Signed-off-by: Jingru Wang <jingru@synopsys.com>