### PR TITLE
makefile: check openocd and set scripts root

### DIFF
--- a/options/scripts.mk
+++ b/options/scripts.mk
@@ -60,6 +60,7 @@ ifeq "$(HOST_OS)" "Windows"
 	ECHO=$(DOS_CMD) echo
 	CP=copy /Y
 	MKD = $(DOS_CMD) mkdir
+	WHICH=where
 
 	IFEXISTDIR=$(DOS_CMD) if exist$(space)
 	ENDIFEXISTDIR=$(space)
@@ -87,6 +88,7 @@ ifeq "$(HOST_OS)" "Cygwin"
 	ECHO=echo
 	CP=cp -rf
 	MKD = mkdir -p
+	WHICH=where
 
 	IFEXISTDIR=[ ! -d$(space)
 	ENDIFEXISTDIR=$(space)] ||
@@ -114,6 +116,7 @@ ifeq "$(HOST_OS)" "GNU/Linux"
 	ECHO=echo
 	CP=cp
 	MKD = mkdir -p
+	WHICH=which
 
 	IFEXISTDIR=[ ! -d$(space)
 	ENDIFEXISTDIR=$(space)] ||

--- a/options/toolchain/toolchain_gnu.mk
+++ b/options/toolchain/toolchain_gnu.mk
@@ -148,7 +148,12 @@ endif
 	TCFGEN  = tcfgen
 	TCFTOOL = tcftool
 
-OPENOCD_SCRIPT_ROOT = $(dir $(shell $(CC) --print-prog-name=ld))../../share/openocd/scripts
+OPENOCD_EXECUTABLE_ROOT = $(dir $(shell $(WHICH) openocd))
+ifeq ($(OPENOCD_EXECUTABLE_ROOT), )
+	$(error "Tool openocd - openocd doesn't exist, please install it!")
+else
+	OPENOCD_SCRIPT_ROOT = $(OPENOCD_EXECUTABLE_ROOT)/share/openocd/scripts
+endif
 
 ## Don't change this line
 override OPENOCD_SCRIPT_ROOT := $(subst \,/, $(strip $(OPENOCD_SCRIPT_ROOT)))


### PR DESCRIPTION
We set `OPENOCD_SCRIPT_ROOT` base on gnu root, but there may not openocd under gnu root. For example, if we load gnu by `module load arc_gnu`. 
