### PR TITLE
scripts: ignore overflow error

### DIFF
--- a/example/examples.yaml
+++ b/example/examples.yaml
@@ -18,6 +18,9 @@
 #         core should format as <platform_name>_<platform_version>_<core_name>
 #     extra_args: <list of extra Make arguments>
 #         extra arguments to pass to Make when building or running the example
+#     ignore_overflowed_error: <True|False>
+#         if true, test result will be marked as skipped when example fails 
+#         because of overflow
 #
 examples:
     example.baremetal.arc_feature.udma:
@@ -69,17 +72,15 @@ examples:
         build_only: true
         platform_exclude: nsim
     example.baremetal.openthread.cli:
+        ignore_overflowed_error: true
         tags: bootloader
         build_only: true
         platform_allow: emsk iotdk
-        core_exlude:
-            - emsk_23_arcem9d
     example.baremetal.openthread.ncp:
+        ignore_overflowed_error: true
         tags: bootloader
         build_only: true
         platform_allow: emsk iotdk
-        core_exlude:
-            - emsk_23_arcem9d
     example.baremetal.secureshield.secret_normal:
         skip: true
         tags: mpu secureshield
@@ -120,14 +121,15 @@ examples:
         tags: blinky
         build_only: true
     example.freertos.iot.coap.coap_server:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: nsim
     example.freertos.iot.lwm2m.lwm2m_client:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: nsim
-        core_exlude:
-            - emsk_23_arcem9d
     example.freertos.iot.lwm2m.lwm2m_server:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: nsim
     example.freertos.kernel:
@@ -138,26 +140,26 @@ examples:
         platform_allow:
             emsk: 23
     example.freertos.net.httpserver:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: nsim
     example.freertos.net.ntshell:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: nsim
-        core_exlude:
-            - emsk_23_arcem9d
     example.freertos.sec.mbedtls.dtls.client:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: iotdk nsim hsdk
     example.freertos.sec.mbedtls.dtls.server:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: iotdk nsim hsdk
     example.freertos.sec.mbedtls.ssl.client2:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: iotdk nsim hsdk
-        core_exlude:
-            - emsk_23_arcem9d
     example.freertos.sec.mbedtls.ssl.server2:
+        ignore_overflowed_error: true
         build_only: true
         platform_exclude: iotdk nsim hsdk
-        core_exlude:
-            - emsk_23_arcem9d


### PR DESCRIPTION
 Add `ignore_overflowed_error` to examples.yaml. Test result will be marked as `skipped` when example fails because of overflow