### PR TITLE
submodules: shallow submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "os/freertos"]
 	path = os/freertos
 	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git
+	shallow = true


### PR DESCRIPTION
1.  add `shallow = true` to .gitmodules,  then "git submodule update" can optionally clone the submodule repositories shallowly.
2.  add `--depth 1` option when fetch mbedtls repo. If fail, then fetch the default branch