### PR TITLE
example: add spi slave example

### DIFF
--- a/example/baremetal/spi_slave/README.rst
+++ b/example/baremetal/spi_slave/README.rst
@@ -1,0 +1,152 @@
+.. _example_spi_slave:
+
+SPI_SLAVE
+#########
+
+Overview
+********
+
+ This example shows SPI driver polling mode usage for both master and slave.
+
+Detailed Description
+====================
+ * Extra Required Tools
+    jumper wire
+
+ * Extra Required Peripherals
+    NO
+
+ * Design Concept
+    The master will transfer data to slave. Upon recieving, the slave will loopback the data.
+
+ * Usage Manual
+    This example requires one IoTDK board (as master) and one EMSK board (as slave)
+
+ * Extra Comments
+    NO
+
+Buidling and Running
+********************
+
+Use jumper wire to connect EMSK P1 lower row with IoTDK Pmod_B upper row. For pin map please refer to documents:
+`EMSK <https://foss-for-synopsys-dwc-arc-processors.github.io/embarc_osp/doc/build/html/board/emsk.html#pmod-pins-definition>`_
+`IoTDK <https://foss-for-synopsys-dwc-arc-processors.github.io/embarc_osp/doc/build/html/board/iotdk.html#extension-interfaces>`_
+
+
+.. note:: Make sure you have also connect GND of two boards with jumper wire
+
+
+With two different types of board connected to your computer, an extra command parameter ''DIG_NAME'' is needed to tell which board is which.
+Launch ''Digilent Adept'' which should have been installed along with board driver to get the ''DIG_NAME''. In our developing secnario, the ''DIG_NAME'' for EMSK is TE0604-03
+And the ''DIG_NAME'' for IoTDK is IoTDK. Please noted that the ''DIG_NAME'' may varies from board to board.
+
+*please run EMSK (SPI slave) program first*, tThe commands to run this example are as follows:
+
+.. code-block:: console
+
+    $ cd <embarc_root>/example/baremetal/spi_slave
+    $ make BOARD=emsk BD_VER=22 CUR_CORE=arcem9d DIG_NAME=TE0604-03 run
+
+If you do not have an EMSK development board, you can use the nSIM simulator
+which have been installed in MetaWare IDE.
+
+.. code-block:: console
+
+    $ cd <embarc_root>/example/baremetal/spi_slave
+    $ make BOARD=iotdk DIG_NAME=IoTDK run
+
+
+Sample Output
+=============
+
+The output from IoTDK (SPI master) are shown below
+
+.. code-block:: console
+
+    -----------------------------------------------------------
+     ____                                _ ____
+    |  _ \ _____      _____ _ __ ___  __| | __ ) _   _
+    | |_) / _ \ \ /\ / / _ \ '__/ _ \/ _` |  _ \| | | |
+    |  __/ (_) \ V  V /  __/ | |  __/ (_| | |_) | |_| |
+    |_|   \___/ \_/\_/ \___|_|  \___|\__,_|____/ \__, |
+                                                 |___/
+                         _       _    ____   ____
+           ___ _ __ ___ | |__   / \  |  _ \ / ___|
+          / _ \ '_ ` _ \| '_ \ / _ \ | |_) | |
+         |  __/ | | | | | |_) / ___ \|  _ <| |___
+          \___|_| |_| |_|_.__/_/   \_\_| \_\\____|
+    ------------------------------------------------------------
+
+    embARC Build Time: Oct 13 2021, 10:35:16
+    Compiler Version: Metaware, Clang 11.1.0
+    PI Master & Slave test Oct 13 2021 / 14:42:48
+    IoTDK Pmod B upper row is working as SPI Master
+    SPI Master is successfully opened
+    SPI Master Buffer
+    TX: 0x0 0x0 0x0 0x0
+    RX: 0x0 0x0 0x0 0x0
+    SPI Master Buffer
+    TX: 0x1 0x1 0x1 0x1
+    RX: 0x0 0x0 0x0 0x0
+    SPI Master Buffer
+    TX: 0x2 0x2 0x2 0x2
+    RX: 0x1 0x1 0x1 0x1
+    SPI Master Buffer
+    TX: 0x3 0x3 0x3 0x3
+    RX: 0x2 0x2 0x2 0x2
+    SPI Master Buffer
+    TX: 0x4 0x4 0x4 0x4
+    RX: 0x3 0x3 0x3 0x3
+    SPI Master Buffer
+    TX: 0x5 0x5 0x5 0x5
+    RX: 0x4 0x4 0x4 0x4
+    SPI Master Buffer
+    TX: 0x6 0x6 0x6 0x6
+    RX: 0x5 0x5 0x5 0x5
+    .................
+
+The output from EMSK (SPI slave) are shown below
+
+.. code-block:: console
+
+    -----------------------------------------------------------
+     ____                                _ ____
+    |  _ \ _____      _____ _ __ ___  __| | __ ) _   _
+    | |_) / _ \ \ /\ / / _ \ '__/ _ \/ _` |  _ \| | | |
+    |  __/ (_) \ V  V /  __/ | |  __/ (_| | |_) | |_| |
+    |_|   \___/ \_/\_/ \___|_|  \___|\__,_|____/ \__, |
+                                                 |___/
+                         _       _    ____   ____
+           ___ _ __ ___ | |__   / \  |  _ \ / ___|
+          / _ \ '_ ` _ \| '_ \ / _ \ | |_) | |
+         |  __/ | | | | | |_) / ___ \|  _ <| |___
+          \___|_| |_| |_|_.__/_/   \_\_| \_\\____|
+    ------------------------------------------------------------
+
+    embARC Build Time: Oct 11 2021, 10:12:43
+    Compiler Version: Metaware, Clang 11.1.0
+    SPI Master & Slave test Oct 13 2021 / 14:42:47
+    EMSK Pmod 1 (J1) lower row is working as SPI Slave
+    SPI Slave is successfully opened
+    SPI Slave Buffer
+    TX: 0x0 0x0 0x0 0x0
+    RX: 0x0 0x0 0x0 0x0
+    SPI Slave Buffer
+    TX: 0x0 0x0 0x0 0x0
+    RX: 0x1 0x1 0x1 0x1
+    SPI Slave Buffer
+    TX: 0x1 0x1 0x1 0x1
+    RX: 0x2 0x2 0x2 0x2
+    SPI Slave Buffer
+    TX: 0x2 0x2 0x2 0x2
+    RX: 0x3 0x3 0x3 0x3
+    SPI Slave Buffer
+    TX: 0x3 0x3 0x3 0x3
+    RX: 0x4 0x4 0x4 0x4
+    SPI Slave Buffer
+    TX: 0x4 0x4 0x4 0x4
+    RX: 0x5 0x5 0x5 0x5
+    SPI Slave Buffer
+    TX: 0x5 0x5 0x5 0x5
+    RX: 0x6 0x6 0x6 0x6
+    .................

--- a/example/baremetal/spi_slave/main.c
+++ b/example/baremetal/spi_slave/main.c
@@ -1,0 +1,123 @@
+/* ------------------------------------------
+ * Copyright (c) 2021, Synopsys, Inc. All rights reserved.
+
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+
+ * 1) Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+
+ * 2) Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation and/or
+ * other materials provided with the distribution.
+
+ * 3) Neither the name of the Synopsys, Inc., nor the names of its contributors may
+ * be used to endorse or promote products derived from this software without
+ * specific prior written permission.
+
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+   --------------------------------------------- */
+#include "embARC.h"
+#include "embARC_debug.h"
+
+#define BUFFER_SIZE 4
+
+void printbuffer(uint8_t *tx, uint8_t *rx)
+{
+#ifdef BOARD_EMSK
+	EMBARC_PRINTF("SPI Slave Buffer\n");
+#elif defined BOARD_IOTDK
+	EMBARC_PRINTF("SPI Master Buffer\n");
+#endif
+	EMBARC_PRINTF("TX:");
+	for(uint8_t i = 0; i < BUFFER_SIZE; i++){
+		EMBARC_PRINTF(" 0x%x", tx[i]);
+	}
+	EMBARC_PRINTF("\nRX:");
+	for(uint8_t i = 0; i < BUFFER_SIZE; i++){
+		EMBARC_PRINTF(" 0x%x", rx[i]);
+	}
+	EMBARC_PRINTF("\n");
+	return;
+}
+
+/* Please run EMSK (SPI Slave) first */
+int main(void)
+{
+	unsigned int ercd = 0;
+	EMBARC_PRINTF("SPI Master & Slave test " __DATE__ " / " __TIME__ " \n");
+
+#ifdef BOARD_EMSK
+	EMBARC_PRINTF("EMSK Pmod 1 (J1) lower row is working as SPI Slave\n");
+
+	DEV_SPI_PTR pSpiSlave = spi_get_dev(DW_SPI_1_ID);
+
+	ercd = pSpiSlave->spi_open(DEV_SLAVE_MODE, SPI_CLK_MODE_0);
+	if ((ercd == E_OPNED) || (ercd == E_OK)) {
+		EMBARC_PRINTF("SPI Slave is successfully opened\n");
+	} else {
+		EMBARC_PRINTF("SPI Slave is unable to open: error=%d\nEnd of Test\n", ercd);
+		return E_SYS;
+	}
+	DEV_SPI_TRANSFER spi_s_xfer;
+	uint8_t  spi_s_buffer_tx[BUFFER_SIZE]={0};
+	uint8_t  spi_s_buffer_rx[BUFFER_SIZE]={0};
+	DEV_SPI_XFER_SET_TXBUF(&spi_s_xfer, spi_s_buffer_tx, 0, BUFFER_SIZE);
+	DEV_SPI_XFER_SET_RXBUF(&spi_s_xfer, spi_s_buffer_rx, 0, BUFFER_SIZE);
+	DEV_SPI_XFER_SET_NEXT(&spi_s_xfer, NULL);
+
+	while (1) {
+		ercd = pSpiSlave->spi_control(SPI_CMD_TRANSFER_POLLING, CONV2VOID(&spi_s_xfer));
+		printbuffer(spi_s_buffer_tx, spi_s_buffer_rx);
+		// loop back the data
+		for(uint8_t i = 0; i < BUFFER_SIZE; i++){
+			spi_s_buffer_tx[i] = spi_s_buffer_rx[i];
+		}
+		board_delay_ms(500, 1);
+	}
+#elif defined BOARD_IOTDK
+	EMBARC_PRINTF("IoTDK Pmod B upper row is working as SPI Master\n");
+	DEV_SPI_PTR pSpiMaster = spi_get_dev(DFSS_SPI_1_ID);
+	ercd = pSpiMaster->spi_open(DEV_MASTER_MODE, 1000000);
+	if ((ercd == E_OPNED) || (ercd == E_OK)) {
+		EMBARC_PRINTF("SPI Master is successfully opened\n");
+		ercd = pSpiMaster->spi_control(SPI_CMD_SET_CLK_MODE, CONV2VOID(SPI_CLK_MODE_0));
+	} else {
+		EMBARC_PRINTF("SPI Master is unable to open: error=%d\nEnd of Test\n", ercd);
+		return E_SYS;
+	}
+	DEV_SPI_TRANSFER spi_m_xfer;
+	uint8_t  spi_m_buffer_tx[BUFFER_SIZE]={0};
+	uint8_t  spi_m_buffer_rx[BUFFER_SIZE]={0};
+	DEV_SPI_XFER_SET_TXBUF(&spi_m_xfer, spi_m_buffer_tx, 0, BUFFER_SIZE);
+	DEV_SPI_XFER_SET_RXBUF(&spi_m_xfer, spi_m_buffer_rx, 0, BUFFER_SIZE);
+	DEV_SPI_XFER_SET_NEXT(&spi_m_xfer, NULL);
+
+	while (1) {
+		ercd = pSpiMaster->spi_control(SPI_CMD_MST_SEL_DEV, CONV2VOID(0));
+		ercd = pSpiMaster->spi_control(SPI_CMD_TRANSFER_POLLING, CONV2VOID(&spi_m_xfer));
+		ercd = pSpiMaster->spi_control(SPI_CMD_MST_DSEL_DEV, CONV2VOID(0));
+		printbuffer(spi_m_buffer_tx, spi_m_buffer_rx);
+		for(uint8_t i = 0; i < BUFFER_SIZE; i++){
+			spi_m_buffer_tx[i]++;
+		}
+		board_delay_ms(3000, 1);
+	}
+
+#else
+	EMBARC_PRINTF("This example is not supported under current configurations \r\n");
+#endif
+
+
+	return E_SYS;
+}

--- a/example/baremetal/spi_slave/makefile
+++ b/example/baremetal/spi_slave/makefile
@@ -1,0 +1,23 @@
+# Application name
+APPL ?= spi_slave
+
+#
+# root dir of embARC
+#
+EMBARC_ROOT = ../../..
+
+MID_SEL = common
+
+# application source dirs
+APPL_CSRC_DIR = .
+APPL_ASMSRC_DIR = .
+
+# application include dirs
+APPL_INC_DIR = .
+
+# include current project makefile
+COMMON_COMPILE_PREREQUISITES += makefile
+
+### Options above must be added before include options.mk ###
+# include key embARC build system makefile
+include $(EMBARC_ROOT)/options/options.mk


### PR DESCRIPTION
Use IoTDK board as SPI master and send data to EMSK as SPI Slave. The example shows how to use SPI driver with polling mode for both master and slave.