### PR TITLE
arch: arc: fix usermode detection

### DIFF
--- a/include/arc/arc_builtin.h
+++ b/include/arc/arc_builtin.h
@@ -434,7 +434,7 @@ Inline uint32_t arc_in_user_mode(void)
     : "i" (AUX_STATUS32)
     : "memory");
 
-  return !(status & AUX_STATUS_MASK_US) ? 1 : 0;
+  return (status & AUX_STATUS_MASK_U) ? 1 : 0;
 }
 
 /**


### PR DESCRIPTION
The usermode state wasn't detected correctly. Fix this. Can be critical for secureshield users.