### PR TITLE
arch: arc: fix size of sections

### DIFF
--- a/options/toolchain/linker_template_gnu.ld
+++ b/options/toolchain/linker_template_gnu.ld
@@ -65,6 +65,7 @@ SECTIONS
 	{
 		_f_text = .;
 		*(.text .text.* .gnu.linkonce.t.*)
+		. = ALIGN(4);
 		_e_text = .;
 	} > REGION_ROM
 
@@ -92,6 +93,7 @@ SECTIONS
 		__DTOR_END__ = .;
 
 		*(.rodata .rodata.* .gnu.linkonce.r.*)
+		. = ALIGN(4);
 		_e_rodata = .;
 	} > REGION_ROM
 
@@ -111,6 +113,7 @@ SECTIONS
 		_e_sbss = .;
 		PROVIDE (__sbss_end = .);
 		PROVIDE (___sbss_end = .);
+		. = ALIGN(4);
 		_e_sdata = .;
 		_e_data = .;
 	} > REGION_RAM AT > REGION_ROM
@@ -121,6 +124,7 @@ SECTIONS
 		*(.dynbss)
 		*(.bss .bss.* .gnu.linkonce.b.*)
 		*(COMMON)
+		. = ALIGN(4);
 		_e_bss = .;
 	} > REGION_RAM
 
@@ -129,6 +133,7 @@ SECTIONS
 		. = ALIGN(4);
 		_f_stack = .;
 		. = . + _STACKSIZE;
+		. = ALIGN(4);
 		_e_stack = .;
 	} > REGION_RAM
 
@@ -138,6 +143,7 @@ SECTIONS
 		__start_heap = . ;
 		_f_heap = .;
 		. = . + _HEAPSIZE;
+		. = ALIGN(4);
 		_e_heap = .;
 		__end_heap = . ;
 	} > REGION_RAM

--- a/options/toolchain/linker_template_mw.ld
+++ b/options/toolchain/linker_template_mw.ld
@@ -71,6 +71,7 @@ SECTIONS {
 			_f_text = .;
 			*(TYPE text)
 			*(.text*)
+			. = ALIGN(4);
 			_e_text = .;
 		}
 
@@ -89,6 +90,7 @@ SECTIONS {
 
 			*(TYPE lit)
 
+			. = ALIGN(4);
 			_e_rodata = .;
 		}
 
@@ -101,11 +103,13 @@ SECTIONS {
 			_f_sdata = .;
 			*(.sdata)
 			*(.sbss)
+			. = ALIGN(4);
 			_e_sdata = .;
 			*(TYPE data)
 		}
 		.tls ALIGN(8): {
 			*(.tls*)
+			. = ALIGN(4);
 			_e_data = .;
 		}
 	} > REGION_RAM
@@ -114,6 +118,7 @@ SECTIONS {
 		.bss ALIGN(8): {
 			_f_bss = .;
 			*(TYPE bss)
+			. = ALIGN(4);
 			_e_bss = .;
 		}
 		.stack ALIGN(4) SIZE(_STACKSIZE): {}


### PR DESCRIPTION
Startup code may have exceeded the sections sizes while clear/copy them and erase data beyond its boundaries.
-------------------------8-------------------------- _s3_clear_bss:
	mov	r0, _f_bss
	mov	r1, _e_bss
	cmp	r0, r1
	jge	_arc_reset_call_main
	mov	r2, 0
_s3_clear_bss_loop:
	st.ab	r2, [r0, 4]
	cmp	r0, r1
	jlt	_s3_clear_bss_loop
-------------------------8------------------------- Since we use 4 byte load/store instructions while working with sections let's align section boundaries to the same 4 bytes.
