### PR TITLE
Fix last-address calculate error in norflash_erase

### DIFF
--- a/device/peripheral/flash/fl256s/spi_flash_fl256s.c
+++ b/device/peripheral/flash/fl256s/spi_flash_fl256s.c
@@ -320,7 +320,7 @@ int32_t fl256s_erase(FL256S_DEF_PTR dev, uint32_t address, uint32_t size)
 	DEV_SPI_TRANSFER cmd_xfer;
 
 	// start address of last sector
-	last_address = (address + size) & (~(dev->sector_sz - 1));
+	last_address = (address + size - 1) & (~(dev->sector_sz - 1));
 
 	// start address of first sector
 	address &= ~(dev->sector_sz - 1);

--- a/device/peripheral/flash/w25qxx/spi_flash_w25qxx.c
+++ b/device/peripheral/flash/w25qxx/spi_flash_w25qxx.c
@@ -264,7 +264,7 @@ int32_t w25qxx_erase(W25QXX_DEF_PTR dev, uint32_t address, uint32_t size)
 	DEV_SPI_TRANSFER cmd_xfer;
 
 	// start address of last sector
-	last_address = (address + size) & (~(dev->sector_sz - 1));
+	last_address = (address + size - 1) & (~(dev->sector_sz - 1));
 
 	// start address of first sector
 	address &= ~(dev->sector_sz - 1);

--- a/example/baremetal/dma_spiflash/spi_flash.c
+++ b/example/baremetal/dma_spiflash/spi_flash.c
@@ -442,7 +442,7 @@ int32_t spiflash_erase(uint32_t address, uint32_t size)
 	SPI_XFER cmd_xfer;
 
 	// start address of last sector
-	last_address = (address + size) & (~(FLASH_SECTOR_SIZE - 1));
+	last_address = (address + size - 1) & (~(FLASH_SECTOR_SIZE - 1));
 
 	// start address of first sector
 	address &= ~(FLASH_SECTOR_SIZE - 1);


### PR DESCRIPTION
# Summary
- Fix issue: https://github.com/foss-for-synopsys-dwc-arc-processors/embarc_osp/issues/179#issue-2260797778

# ToDos
- I only fixed 3 norflash-related code issues, and there are probably similar bugs somewhere.
